### PR TITLE
Add LMP Pricing Data for CAISO, NYISO, MISO, and ISONE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - ISONE: add lmp prices for 3 markets: real time 5 minutes, real time hourly, day ahead hourly
 - ERCOT:
 
+Todos
+
+- doucment query date for day ahead market
+
 ## v0.4.0 - Aug 4, 2022
 
 - NYISO: added all demand, fuel mix, and supply methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 - CAISO: added LMP prices for 3 market: real time 15 minute (FMM), real time hours (HASP), day ahead hourly (DAM)
 - NYISO: added LMP prices for 2 markets: real time 5 minute and day ahead 5 minute
 - MISO: added LMP prices for 2 market: real time 5 minute and day head hourly
+- ISONE: add lmp prices for 3 markets: real time 5 minutes, real time hourly, day ahead hourly
 - PJM: blocked on finding current day
 - SPP: data available, but what nodes?
-- ISONE: add lmp prices for 3 markets: real time 5 minutes, real time hourly, day ahead hourly
 - ERCOT:
 - Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## vNext
+
+- NYISO: add LMP prices for 2 markets: real time 5 minute & day ahead 5 minute
+- CAISO: blocked on timeout errors add LMP prices for 1 market: day ahead hourly
+- MISO: add LMP prices for 2 market: real time 5 minute and day head hourly
+- PJM: blocked on finding current day
+- SPP: data available, but what nodes?
+- ISONE: add lmp prices for 3 markets: real time 5 minutes, real time hourly, day ahead hourly
+- ERCOT:
+
 ## v0.4.0 - Aug 4, 2022
 
 - NYISO: added all demand, fuel mix, and supply methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## vNext
 
-- NYISO: add LMP prices for 2 markets: real time 5 minute & day ahead 5 minute
-- CAISO: blocked on timeout errors add LMP prices for 1 market: day ahead hourly
-- MISO: add LMP prices for 2 market: real time 5 minute and day head hourly
+- NYISO: added LMP prices for 2 markets: real time 5 minute and day ahead 5 minute
+- CAISO: added LMP prices for 2 market: real time 15 minute and day ahead hourly
+- MISO: added LMP prices for 2 market: real time 5 minute and day head hourly
 - PJM: blocked on finding current day
 - SPP: data available, but what nodes?
 - ISONE: add lmp prices for 3 markets: real time 5 minutes, real time hourly, day ahead hourly
 - ERCOT:
+
+https://www.ercot.com/mp/data-products/markets/real-time-market?id=NP6-788-CD
+
+https://www.ercot.com/misdownload/servlets/mirDownload?doclookupId=856969377
 
 Todos
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## vNext
 
+- CAISO: added LMP prices for 3 market: real time 15 minute (FMM), real time hours (HASP), day ahead hourly (DAM)
 - NYISO: added LMP prices for 2 markets: real time 5 minute and day ahead 5 minute
-- CAISO: added LMP prices for 2 market: real time 15 minute and day ahead hourly
 - MISO: added LMP prices for 2 market: real time 5 minute and day head hourly
 - PJM: blocked on finding current day
 - SPP: data available, but what nodes?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,7 @@
 - NYISO: added LMP prices for 2 markets: real time 5 minute and day ahead 5 minute
 - MISO: added LMP prices for 2 market: real time 5 minute and day head hourly
 - ISONE: add lmp prices for 3 markets: real time 5 minutes, real time hourly, day ahead hourly
-- PJM: blocked on finding current day
-- SPP: data available, but what nodes?
-- ERCOT:
-- Bug Fixes
-
-https://www.ercot.com/mp/data-products/markets/real-time-market?id=NP6-788-CD
-
-https://www.ercot.com/misdownload/servlets/mirDownload?doclookupId=856969377
-
-Todos
-
-- doucment query date for day ahead market
+- Bug fixes
 
 ## v0.4.0 - Aug 4, 2022
 

--- a/README.md
+++ b/README.md
@@ -215,18 +215,21 @@ And here is querying CAISO
 >>> iso.get_lmp_today(iso.DAY_AHEAD_HOURLY, nodes=None)
 ```
 
-## CAISO
+## Supported LMP Markets
 
-Supported LMP Markets
+<!-- LMP AVAILABILITY TABLE START -->
 
-- DAY_AHEAD_HOURLY
+|                                       | Markets                                                   |
+| :------------------------------------ | :-------------------------------------------------------- |
+| Midcontinent ISO                      | `REAL_TIME_5_MIN`, `DAY_AHEAD_HOURLY`                     |
+| California ISO                        | `REAL_TIME_15_MIN`, `DAY_AHEAD_HOURLY`                    |
+| PJM                                   |                                                           |
+| Electric Reliability Council of Texas |                                                           |
+| Southwest Power Pool                  |                                                           |
+| New York ISO                          | `REAL_TIME_5_MIN`, `DAY_AHEAD_5_MIN`                      |
+| ISO New England                       | `REAL_TIME_5_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY` |
 
-## NYISO
-
-Supported LMP Markets
-
-- REAL_TIME_5_MIN
-- DAY_AHEAD_5_MIN
+<!-- LMP AVAILABILITY TABLE END -->
 
 ## Feedback Welcome
 

--- a/README.md
+++ b/README.md
@@ -161,23 +161,21 @@ The best part is these APIs work across all the supported ISOs
 Here is the current status of availability of each method for each ISO
 
 <!-- METHOD AVAILABILITY TABLE START -->
-
-|                           | New York ISO | California ISO | Electric Reliability Council of Texas | ISO New England | Midcontinent ISO | Southwest Power Pool | PJM      |
-| :------------------------ | :----------- | :------------- | :------------------------------------ | :-------------- | :--------------- | :------------------- | :------- |
-| `get_latest_status`       | &#10060;     | &#x2705;       | &#x2705;                              | &#10060;        | &#10060;         | &#10060;             | &#10060; |
-| `get_latest_fuel_mix`     | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
-| `get_fuel_mix_today`      | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_fuel_mix_yesterday`  | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_historical_fuel_mix` | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_latest_demand`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
-| `get_demand_today`        | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
-| `get_demand_yesterday`    | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_historical_demand`   | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_latest_supply`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
-| `get_supply_today`        | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_supply_yesterday`    | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_historical_supply`   | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-
+|                           | New York ISO   | California ISO   | Electric Reliability Council of Texas   | ISO New England   | Midcontinent ISO   | Southwest Power Pool   | PJM      |
+|:--------------------------|:---------------|:-----------------|:----------------------------------------|:------------------|:-------------------|:-----------------------|:---------|
+| `get_latest_status`       | &#10060;       | &#x2705;         | &#x2705;                                | &#10060;          | &#10060;           | &#10060;               | &#10060; |
+| `get_latest_fuel_mix`     | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
+| `get_fuel_mix_today`      | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_fuel_mix_yesterday`  | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_historical_fuel_mix` | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_latest_demand`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
+| `get_demand_today`        | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
+| `get_demand_yesterday`    | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_historical_demand`   | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_latest_supply`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
+| `get_supply_today`        | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_supply_yesterday`    | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_historical_supply`   | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
 <!-- METHOD AVAILABILITY TABLE END -->
 
 ## LMP Pricing Data
@@ -218,9 +216,8 @@ And here is querying CAISO
 ## Supported LMP Markets
 
 <!-- LMP AVAILABILITY TABLE START -->
-
 |                                       | Markets                                                   |
-| :------------------------------------ | :-------------------------------------------------------- |
+|:--------------------------------------|:----------------------------------------------------------|
 | Midcontinent ISO                      | `REAL_TIME_5_MIN`, `DAY_AHEAD_HOURLY`                     |
 | California ISO                        | `REAL_TIME_15_MIN`, `DAY_AHEAD_HOURLY`                    |
 | PJM                                   |                                                           |
@@ -228,7 +225,6 @@ And here is querying CAISO
 | Southwest Power Pool                  |                                                           |
 | New York ISO                          | `REAL_TIME_5_MIN`, `DAY_AHEAD_5_MIN`                      |
 | ISO New England                       | `REAL_TIME_5_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY` |
-
 <!-- LMP AVAILABILITY TABLE END -->
 
 ## Feedback Welcome

--- a/README.md
+++ b/README.md
@@ -161,63 +161,72 @@ The best part is these APIs work across all the supported ISOs
 Here is the current status of availability of each method for each ISO
 
 <!-- METHOD AVAILABILITY TABLE START -->
-|                           | New York ISO   | California ISO   | Electric Reliability Council of Texas   | ISO New England   | Midcontinent ISO   | Southwest Power Pool   | PJM      |
-|:--------------------------|:---------------|:-----------------|:----------------------------------------|:------------------|:-------------------|:-----------------------|:---------|
-| `get_latest_status`       | &#10060;       | &#x2705;         | &#x2705;                                | &#10060;          | &#10060;           | &#10060;               | &#10060; |
-| `get_latest_fuel_mix`     | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_fuel_mix_today`      | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_fuel_mix_yesterday`  | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_historical_fuel_mix` | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_latest_demand`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_demand_today`        | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_demand_yesterday`    | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_historical_demand`   | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_latest_supply`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_supply_today`        | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_supply_yesterday`    | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_historical_supply`   | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+
+|                           | New York ISO | California ISO | Electric Reliability Council of Texas | ISO New England | Midcontinent ISO | Southwest Power Pool | PJM      |
+| :------------------------ | :----------- | :------------- | :------------------------------------ | :-------------- | :--------------- | :------------------- | :------- |
+| `get_latest_status`       | &#10060;     | &#x2705;       | &#x2705;                              | &#10060;        | &#10060;         | &#10060;             | &#10060; |
+| `get_latest_fuel_mix`     | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_fuel_mix_today`      | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_fuel_mix_yesterday`  | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_historical_fuel_mix` | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_latest_demand`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_demand_today`        | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_demand_yesterday`    | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_historical_demand`   | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_latest_supply`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_supply_today`        | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_supply_yesterday`    | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_historical_supply`   | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+
 <!-- METHOD AVAILABILITY TABLE END -->
 
-## Pricing Data
+## LMP Pricing Data
 
-We are investigating adding pricing data to `isodata`. Currently, day ahead prices are supported for CAISO. If this would be useful, please let us know by filing an issue and describing your use case.
+We are currently adding Locational Marginal Price (LMP). Even though each BA offers different markets, but you can query them with a standardized API
 
 ```python
 >>> import isodata
->>> iso = isodata.CAISO()
->>> iso.get_day_ahead_prices(start_date="may 2, 2022",
-                         num_days=1,
-                         nodes=["TH_NP15_GEN-APND"])
+>>> iso = isodata.NYISO()
+>>> iso.get_lmp_today(iso.REAL_TIME_5_MIN, nodes="ALL")
 ```
 
 ```
-LMP_TYPE	pnode	lmp	congestion	energy	losses	MGHG
-interval start
-2022-05-02 00:00:00-07:00	TH_NP15_GEN-APND	70.47015	0.00000	71.55783	-1.08768	0.0
-2022-05-02 01:00:00-07:00	TH_NP15_GEN-APND	68.73617	0.00000	69.86093	-1.12476	0.0
-2022-05-02 02:00:00-07:00	TH_NP15_GEN-APND	67.58898	0.00000	68.82788	-1.23890	0.0
-2022-05-02 03:00:00-07:00	TH_NP15_GEN-APND	68.51088	0.00000	69.64611	-1.13523	0.0
-2022-05-02 04:00:00-07:00	TH_NP15_GEN-APND	74.25415	0.00000	75.56136	-1.30721	0.0
-2022-05-02 05:00:00-07:00	TH_NP15_GEN-APND	77.86464	0.00000	79.62434	-1.75970	0.0
-2022-05-02 06:00:00-07:00	TH_NP15_GEN-APND	80.71256	0.00000	82.11675	-1.40420	0.0
-2022-05-02 07:00:00-07:00	TH_NP15_GEN-APND	66.68011	0.00000	67.15016	-0.47005	0.0
-2022-05-02 08:00:00-07:00	TH_NP15_GEN-APND	56.40186	7.88764	48.52878	-0.01456	0.0
-2022-05-02 09:00:00-07:00	TH_NP15_GEN-APND	48.69254	9.08351	39.49055	0.11847	0.0
-2022-05-02 10:00:00-07:00	TH_NP15_GEN-APND	41.55114	8.09662	33.41776	0.03676	0.0
-2022-05-02 11:00:00-07:00	TH_NP15_GEN-APND	38.59000	10.35001	28.20333	0.03666	0.0
-2022-05-02 12:00:00-07:00	TH_NP15_GEN-APND	36.89000	8.04264	28.82718	0.02018	0.0
-2022-05-02 13:00:00-07:00	TH_NP15_GEN-APND	38.34660	8.08619	30.11885	0.14156	0.0
-2022-05-02 14:00:00-07:00	TH_NP15_GEN-APND	40.00000	7.97681	31.85753	0.16566	0.0
-2022-05-02 15:00:00-07:00	TH_NP15_GEN-APND	40.00000	6.59597	33.42743	-0.02340	0.0
-2022-05-02 16:00:00-07:00	TH_NP15_GEN-APND	45.31324	8.08926	36.76443	0.45956	0.0
-2022-05-02 17:00:00-07:00	TH_NP15_GEN-APND	59.39957	2.43405	56.88020	0.08532	0.0
-2022-05-02 18:00:00-07:00	TH_NP15_GEN-APND	81.43412	0.00000	83.73688	-2.30276	0.0
-2022-05-02 19:00:00-07:00	TH_NP15_GEN-APND	100.77406	0.00000	104.60251	-3.82845	0.0
-2022-05-02 20:00:00-07:00	TH_NP15_GEN-APND	102.88135	0.00000	105.97585	-3.09449	0.0
-2022-05-02 21:00:00-07:00	TH_NP15_GEN-APND	91.42214	0.00000	94.18167	-2.75952	0.0
-2022-05-02 22:00:00-07:00	TH_NP15_GEN-APND	81.84891	0.00000	83.61315	-1.76424	0.0
-2022-05-02 23:00:00-07:00	TH_NP15_GEN-APND	72.61741	0.00000	73.53662	-0.91921	0.0
+                          Time           Market    Zone     LMP  Energy  Congestion  Losses
+0    2022-08-08 00:05:00-04:00  REAL_TIME_5_MIN  CAPITL  125.15   90.63      -26.64    7.88
+1    2022-08-08 00:05:00-04:00  REAL_TIME_5_MIN  CENTRL   92.17   90.63        0.00    1.54
+2    2022-08-08 00:05:00-04:00  REAL_TIME_5_MIN  DUNWOD   99.52   90.63        0.00    8.89
+3    2022-08-08 00:05:00-04:00  REAL_TIME_5_MIN  GENESE   92.53   90.62        0.00    1.91
+4    2022-08-08 00:05:00-04:00  REAL_TIME_5_MIN     H Q   88.09   90.63        0.00   -2.54
+...                        ...              ...     ...     ...     ...         ...     ...
+3970 2022-08-08 22:00:00-04:00  REAL_TIME_5_MIN   NORTH  110.17  120.71        7.04   -3.50
+3971 2022-08-08 22:00:00-04:00  REAL_TIME_5_MIN     NPX  236.60  120.72     -107.18    8.70
+3972 2022-08-08 22:00:00-04:00  REAL_TIME_5_MIN     O H  121.23  120.72       -4.49   -3.98
+3973 2022-08-08 22:00:00-04:00  REAL_TIME_5_MIN     PJM  146.13  120.71      -20.23    5.19
+3974 2022-08-08 22:00:00-04:00  REAL_TIME_5_MIN    WEST  125.26  120.72       -5.02   -0.48
+
+[3975 rows x 7 columns]
 ```
+
+And here is querying CAISO
+
+```
+>>> import isodata
+>>> iso = isodata.CAISO()
+>>> iso.get_lmp_today(iso.DAY_AHEAD_HOURLY, nodes=None)
+```
+
+## CAISO
+
+Supported LMP Markets
+
+- DAY_AHEAD_HOURLY
+
+## NYISO
+
+Supported LMP Markets
+
+- REAL_TIME_5_MIN
+- DAY_AHEAD_5_MIN
 
 ## Feedback Welcome
 

--- a/README.md
+++ b/README.md
@@ -162,23 +162,21 @@ The best part is these APIs work across all the supported ISOs
 Here is the current status of availability of each method for each ISO
 
 <!-- METHOD AVAILABILITY TABLE START -->
-
-|                           | New York ISO | California ISO | Electric Reliability Council of Texas | ISO New England | Midcontinent ISO | Southwest Power Pool | PJM      |
-| :------------------------ | :----------- | :------------- | :------------------------------------ | :-------------- | :--------------- | :------------------- | :------- |
-| `get_latest_status`       | &#10060;     | &#x2705;       | &#x2705;                              | &#10060;        | &#10060;         | &#10060;             | &#10060; |
-| `get_latest_fuel_mix`     | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
-| `get_fuel_mix_today`      | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_fuel_mix_yesterday`  | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_historical_fuel_mix` | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_latest_demand`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
-| `get_demand_today`        | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
-| `get_demand_yesterday`    | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_historical_demand`   | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_latest_supply`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
-| `get_supply_today`        | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_supply_yesterday`    | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_historical_supply`   | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-
+|                           | New York ISO   | California ISO   | Electric Reliability Council of Texas   | ISO New England   | Midcontinent ISO   | Southwest Power Pool   | PJM      |
+|:--------------------------|:---------------|:-----------------|:----------------------------------------|:------------------|:-------------------|:-----------------------|:---------|
+| `get_latest_status`       | &#10060;       | &#x2705;         | &#x2705;                                | &#10060;          | &#10060;           | &#10060;               | &#10060; |
+| `get_latest_fuel_mix`     | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
+| `get_fuel_mix_today`      | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_fuel_mix_yesterday`  | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_historical_fuel_mix` | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_latest_demand`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
+| `get_demand_today`        | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
+| `get_demand_yesterday`    | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_historical_demand`   | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_latest_supply`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
+| `get_supply_today`        | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_supply_yesterday`    | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_historical_supply`   | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
 <!-- METHOD AVAILABILITY TABLE END -->
 
 ## LMP Pricing Data
@@ -219,9 +217,8 @@ And here is querying CAISO
 ## Supported LMP Markets
 
 <!-- LMP AVAILABILITY TABLE START -->
-
 |                                       | Markets                                                    |
-| :------------------------------------ | :--------------------------------------------------------- |
+|:--------------------------------------|:-----------------------------------------------------------|
 | Midcontinent ISO                      | `REAL_TIME_5_MIN`, `DAY_AHEAD_HOURLY`                      |
 | California ISO                        | `REAL_TIME_15_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY` |
 | PJM                                   |                                                            |
@@ -229,7 +226,6 @@ And here is querying CAISO
 | Southwest Power Pool                  |                                                            |
 | New York ISO                          | `REAL_TIME_5_MIN`, `DAY_AHEAD_5_MIN`                       |
 | ISO New England                       | `REAL_TIME_5_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY`  |
-
 <!-- LMP AVAILABILITY TABLE END -->
 
 ## Feedback Welcome

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 <a href="#install"><b>Install</b></a> — 
 <a href="#getting-started"><b>Getting Started</b></a> — 
 <a href="#method-availability"><b>Method Availability</b></a> —  
-<a href="#pricing-data"><b>Pricing Data</b></a> —  
+<a href="#lmp-pricing-data"><b>LMP Data</b></a> —  
+<a href="#supported-lmp-markets"><b>Supported LMP Markets</b></a> —  
 <a href="#feedback-welcome"><b>Feedback</b></a>
 </p>
 
@@ -161,21 +162,23 @@ The best part is these APIs work across all the supported ISOs
 Here is the current status of availability of each method for each ISO
 
 <!-- METHOD AVAILABILITY TABLE START -->
-|                           | New York ISO   | California ISO   | Electric Reliability Council of Texas   | ISO New England   | Midcontinent ISO   | Southwest Power Pool   | PJM      |
-|:--------------------------|:---------------|:-----------------|:----------------------------------------|:------------------|:-------------------|:-----------------------|:---------|
-| `get_latest_status`       | &#10060;       | &#x2705;         | &#x2705;                                | &#10060;          | &#10060;           | &#10060;               | &#10060; |
-| `get_latest_fuel_mix`     | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_fuel_mix_today`      | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_fuel_mix_yesterday`  | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_historical_fuel_mix` | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_latest_demand`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_demand_today`        | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_demand_yesterday`    | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_historical_demand`   | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_latest_supply`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_supply_today`        | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_supply_yesterday`    | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_historical_supply`   | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+
+|                           | New York ISO | California ISO | Electric Reliability Council of Texas | ISO New England | Midcontinent ISO | Southwest Power Pool | PJM      |
+| :------------------------ | :----------- | :------------- | :------------------------------------ | :-------------- | :--------------- | :------------------- | :------- |
+| `get_latest_status`       | &#10060;     | &#x2705;       | &#x2705;                              | &#10060;        | &#10060;         | &#10060;             | &#10060; |
+| `get_latest_fuel_mix`     | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_fuel_mix_today`      | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_fuel_mix_yesterday`  | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_historical_fuel_mix` | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_latest_demand`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_demand_today`        | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_demand_yesterday`    | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_historical_demand`   | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_latest_supply`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_supply_today`        | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_supply_yesterday`    | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_historical_supply`   | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+
 <!-- METHOD AVAILABILITY TABLE END -->
 
 ## LMP Pricing Data
@@ -216,8 +219,9 @@ And here is querying CAISO
 ## Supported LMP Markets
 
 <!-- LMP AVAILABILITY TABLE START -->
+
 |                                       | Markets                                                    |
-|:--------------------------------------|:-----------------------------------------------------------|
+| :------------------------------------ | :--------------------------------------------------------- |
 | Midcontinent ISO                      | `REAL_TIME_5_MIN`, `DAY_AHEAD_HOURLY`                      |
 | California ISO                        | `REAL_TIME_15_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY` |
 | PJM                                   |                                                            |
@@ -225,6 +229,7 @@ And here is querying CAISO
 | Southwest Power Pool                  |                                                            |
 | New York ISO                          | `REAL_TIME_5_MIN`, `DAY_AHEAD_5_MIN`                       |
 | ISO New England                       | `REAL_TIME_5_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY`  |
+
 <!-- LMP AVAILABILITY TABLE END -->
 
 ## Feedback Welcome

--- a/README.md
+++ b/README.md
@@ -162,21 +162,23 @@ The best part is these APIs work across all the supported ISOs
 Here is the current status of availability of each method for each ISO
 
 <!-- METHOD AVAILABILITY TABLE START -->
-|                           | New York ISO   | California ISO   | Electric Reliability Council of Texas   | ISO New England   | Midcontinent ISO   | Southwest Power Pool   | PJM      |
-|:--------------------------|:---------------|:-----------------|:----------------------------------------|:------------------|:-------------------|:-----------------------|:---------|
-| `get_latest_status`       | &#10060;       | &#x2705;         | &#x2705;                                | &#10060;          | &#10060;           | &#10060;               | &#10060; |
-| `get_latest_fuel_mix`     | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_fuel_mix_today`      | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_fuel_mix_yesterday`  | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_historical_fuel_mix` | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_latest_demand`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_demand_today`        | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_demand_yesterday`    | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_historical_demand`   | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_latest_supply`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_supply_today`        | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_supply_yesterday`    | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_historical_supply`   | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+
+|                           | New York ISO | California ISO | Electric Reliability Council of Texas | ISO New England | Midcontinent ISO | Southwest Power Pool | PJM      |
+| :------------------------ | :----------- | :------------- | :------------------------------------ | :-------------- | :--------------- | :------------------- | :------- |
+| `get_latest_status`       | &#10060;     | &#x2705;       | &#x2705;                              | &#10060;        | &#10060;         | &#10060;             | &#10060; |
+| `get_latest_fuel_mix`     | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_fuel_mix_today`      | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_fuel_mix_yesterday`  | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_historical_fuel_mix` | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_latest_demand`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_demand_today`        | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_demand_yesterday`    | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_historical_demand`   | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_latest_supply`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_supply_today`        | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_supply_yesterday`    | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_historical_supply`   | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+
 <!-- METHOD AVAILABILITY TABLE END -->
 
 ## LMP Pricing Data
@@ -211,14 +213,32 @@ And here is querying CAISO
 ```
 >>> import isodata
 >>> iso = isodata.CAISO()
->>> iso.get_lmp_today(iso.DAY_AHEAD_HOURLY, nodes=None)
+>>> iso.get_lmp_today(iso.DAY_AHEAD_HOURLY, nodes=["TH_NP15_GEN-APND", "TH_SP15_GEN-APND", "TH_ZP26_GEN-APND"])
+```
+
+```
+LMP_TYPE                      Time                    Market              Node        LMP     Energy  Congestion     Loss
+0        2022-08-12 00:00:00-07:00  Markets.DAY_AHEAD_HOURLY  TH_NP15_GEN-APND   90.17747   97.01718         0.0 -6.83971
+1        2022-08-12 00:00:00-07:00  Markets.DAY_AHEAD_HOURLY  TH_SP15_GEN-APND   95.57163   97.01718         0.0 -1.44556
+2        2022-08-12 00:00:00-07:00  Markets.DAY_AHEAD_HOURLY  TH_ZP26_GEN-APND   92.04020   97.01718         0.0 -4.97698
+3        2022-08-12 01:00:00-07:00  Markets.DAY_AHEAD_HOURLY  TH_NP15_GEN-APND   84.90745   90.76157         0.0 -5.85412
+4        2022-08-12 01:00:00-07:00  Markets.DAY_AHEAD_HOURLY  TH_SP15_GEN-APND   89.18232   90.76157         0.0 -1.57925
+..                             ...                       ...               ...        ...        ...         ...      ...
+67       2022-08-12 22:00:00-07:00  Markets.DAY_AHEAD_HOURLY  TH_SP15_GEN-APND  121.11000  122.06208         0.0 -0.95208
+68       2022-08-12 22:00:00-07:00  Markets.DAY_AHEAD_HOURLY  TH_ZP26_GEN-APND  114.20129  122.06208         0.0 -7.86080
+69       2022-08-12 23:00:00-07:00  Markets.DAY_AHEAD_HOURLY  TH_NP15_GEN-APND  100.50102  109.72925         0.0 -9.22823
+70       2022-08-12 23:00:00-07:00  Markets.DAY_AHEAD_HOURLY  TH_SP15_GEN-APND  108.69780  109.72925         0.0 -1.03145
+71       2022-08-12 23:00:00-07:00  Markets.DAY_AHEAD_HOURLY  TH_ZP26_GEN-APND  103.18939  109.72925         0.0 -6.53986
+
+[72 rows x 7 columns]
 ```
 
 ## Supported LMP Markets
 
 <!-- LMP AVAILABILITY TABLE START -->
+
 |                                       | Markets                                                    |
-|:--------------------------------------|:-----------------------------------------------------------|
+| :------------------------------------ | :--------------------------------------------------------- |
 | Midcontinent ISO                      | `REAL_TIME_5_MIN`, `DAY_AHEAD_HOURLY`                      |
 | California ISO                        | `REAL_TIME_15_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY` |
 | PJM                                   |                                                            |
@@ -226,6 +246,7 @@ And here is querying CAISO
 | Southwest Power Pool                  |                                                            |
 | New York ISO                          | `REAL_TIME_5_MIN`, `DAY_AHEAD_5_MIN`                       |
 | ISO New England                       | `REAL_TIME_5_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY`  |
+
 <!-- LMP AVAILABILITY TABLE END -->
 
 ## Feedback Welcome

--- a/README.md
+++ b/README.md
@@ -216,15 +216,15 @@ And here is querying CAISO
 ## Supported LMP Markets
 
 <!-- LMP AVAILABILITY TABLE START -->
-|                                       | Markets                                                   |
-|:--------------------------------------|:----------------------------------------------------------|
-| Midcontinent ISO                      | `REAL_TIME_5_MIN`, `DAY_AHEAD_HOURLY`                     |
-| California ISO                        | `REAL_TIME_15_MIN`, `DAY_AHEAD_HOURLY`                    |
-| PJM                                   |                                                           |
-| Electric Reliability Council of Texas |                                                           |
-| Southwest Power Pool                  |                                                           |
-| New York ISO                          | `REAL_TIME_5_MIN`, `DAY_AHEAD_5_MIN`                      |
-| ISO New England                       | `REAL_TIME_5_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY` |
+|                                       | Markets                                                    |
+|:--------------------------------------|:-----------------------------------------------------------|
+| Midcontinent ISO                      | `REAL_TIME_5_MIN`, `DAY_AHEAD_HOURLY`                      |
+| California ISO                        | `REAL_TIME_15_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY` |
+| PJM                                   |                                                            |
+| Electric Reliability Council of Texas |                                                            |
+| Southwest Power Pool                  |                                                            |
+| New York ISO                          | `REAL_TIME_5_MIN`, `DAY_AHEAD_5_MIN`                       |
+| ISO New England                       | `REAL_TIME_5_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY`  |
 <!-- LMP AVAILABILITY TABLE END -->
 
 ## Feedback Welcome

--- a/isodata/__init__.py
+++ b/isodata/__init__.py
@@ -3,6 +3,8 @@ from isodata import tests
 from isodata.version import __version__
 import isodata.base
 
+from isodata.base import Markets
+
 import isodata.utils
 
 from isodata.nyiso import NYISO

--- a/isodata/base.py
+++ b/isodata/base.py
@@ -51,22 +51,27 @@ class ISOBase:
     def get_historical_supply(self, date):
         raise NotImplementedError()
 
-    def _latest_from_today(self, method):
-        data = method()
+    def _latest_lmp_from_today(self, market, nodes, node_column="Node"):
+        lmp_df = self.get_lmp_today(market, nodes)
+        latest_df = lmp_df.groupby(node_column).last()
+        return latest_df
+
+    def _latest_from_today(self, method, *args, **kwargs):
+        data = method(*args, **kwargs)
         latest = data.iloc[-1]
 
         latest.index = latest.index.str.lower()
 
         return latest.to_dict()
 
-    def _today_from_historical(self, method):
+    def _today_from_historical(self, method, *args, **kwargs):
         today = pd.Timestamp.now(self.default_timezone).date()
-        return method(today)
+        return method(today, *args, **kwargs)
 
-    def _yesterday_from_historical(self, method):
+    def _yesterday_from_historical(self, method, *args, **kwargs):
         yesterday = (pd.Timestamp.now(self.default_timezone) -
                      pd.DateOffset(1)).date()
-        return method(yesterday)
+        return method(yesterday,  *args, **kwargs)
 
     def _supply_from_fuel_mix(self, date):
         df = self.get_historical_fuel_mix(date)

--- a/isodata/base.py
+++ b/isodata/base.py
@@ -1,8 +1,17 @@
+from enum import Enum
 import pandas as pd
 import requests
 from tabulate import tabulate
 # TODO: this is needed to make SPP request work. restrict only to SPP
 requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS = 'ALL:@SECLEVEL=1'
+
+
+class Markets(Enum):
+    REAL_TIME_5_MIN = "REAL_TIME_5_MIN"
+    REAL_TIME_15_MIN = "REAL_TIME_15_MIN"
+    REAL_TIME_HOURLY = "REAL_TIME_HOURLY"
+    DAY_AHEAD_5_MIN = "DAY_AHEAD_5_MIN"
+    DAY_AHEAD_HOURLY = "DAY_AHEAD_HOURLY"
 
 
 class ISOBase:

--- a/isodata/caiso.py
+++ b/isodata/caiso.py
@@ -5,6 +5,8 @@ from .base import ISOBase, FuelMix, GridStatus
 import pandas as pd
 from typing import Any
 
+import time
+
 
 class CAISO(ISOBase):
     BASE = "https://www.caiso.com/outlook/SP"
@@ -13,6 +15,9 @@ class CAISO(ISOBase):
     name = "California ISO"
     iso_id = "caiso"
     default_timezone = "US/Pacific"
+
+    DAY_AHEAD_HOURLY = "DAY_AHEAD_HOURLY"
+    REAL_TIME_15_MIN = "REAL_TIME_15_MIN"
 
     def _current_day(self):
         # get current date from stats api
@@ -137,14 +142,24 @@ class CAISO(ISOBase):
         })
         return df
 
-    def get_day_ahead_prices(self, start_date, num_days=1, nodes=None):
+    def get_latest_lmp(self, market: str, nodes: list):
+        return self._latest_lmp_from_today(market, nodes, node_column="Node")
+
+    def get_lmp_today(self, market: str, nodes: list):
+        "Get lmp for today in 5 minute intervals"
+        return self._today_from_historical(self.get_historical_lmp, market, nodes)
+
+    def get_lmp_yesterday(self, market: str, nodes: list):
+        "Get lmp for yesterday in 5 minute intervals"
+        return self._yesterday_from_historical(self.get_historical_lmp, market, nodes)
+
+    def get_historical_lmp(self, date, market: str, nodes: list):
         """Get day ahead LMP pricing starting at supplied date for a list of nodes.
 
         Arguments:
-            start_date (str or pd.Timestamp): starting date to return data. Supports starting date up to 39 months ago
+            date: date to return data
 
-
-            num_days: get data for num_days after starting date. Must be less than 31
+            market: market to return from. supports: 
 
             nodes (list): list of nodes to get data from. If no nodes are provided, defaults to NP15, SP15, and ZP26, which are the trading hub nodes. For a list of nodes, call CAISO.get_pnodes()
 
@@ -152,37 +167,54 @@ class CAISO(ISOBase):
             dataframe of pricing data
         """
 
-        if num_days > 31:
-            raise RuntimeError("num_days must be below 31")
-
         if nodes is None:
             nodes = ["TH_NP15_GEN-APND",
                      "TH_SP15_GEN-APND", "TH_ZP26_GEN-APND"]
 
-        if isinstance(start_date, str):
-            start_date = pd.to_datetime(
-                start_date).tz_localize(self.default_timezone)
-
+        # todo make sure defaults to local timezone
+        start = isodata.utils._handle_date(date, tz=self.default_timezone)
         nodes_str = ",".join(nodes)
 
-        start = start_date.tz_convert("UTC")
-        end = start + pd.DateOffset(num_days)
+        start = start.tz_convert("UTC")
+        end = start + pd.DateOffset(1)
 
         start = start.strftime("%Y%m%dT%H:%M-0000")
         end = end.strftime("%Y%m%dT%H:%M-0000")
-        url = f"http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname=PRC_LMP&version=12&startdatetime={start}&enddatetime={end}&market_run_id=DAM&node={nodes_str}"
+
+        if market == self.DAY_AHEAD_HOURLY:
+            url = f"http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname=PRC_LMP&version=12&startdatetime={start}&enddatetime={end}&market_run_id=DAM&node={nodes_str}"
+            PRICE_COL = "MW"
+        elif market == self.REAL_TIME_15_MIN:
+            url = f"http://oasis.caiso.com/oasisapi/SingleZip?resultformat=6&queryname=PRC_RTPD_LMP&version=3&startdatetime={start}&enddatetime={end}&market_run_id=RTPD&node={nodes_str}"
+            PRICE_COL = "PRC"
+
         # todo catch too many requests
-        df = pd.read_csv(url,
-                         compression='zip',
-                         usecols=["INTERVALSTARTTIME_GMT", "NODE", "LMP_TYPE", "MW"])
+        retry_num = 0
+        while retry_num < 3:
+            try:
+                df = pd.read_csv(url,
+                                 compression='zip',
+                                 usecols=["INTERVALSTARTTIME_GMT", "NODE", "LMP_TYPE", PRICE_COL])
+            except Exception as e:
+                retry_num += 1
+                print(f"Failed to get data from CAISO. Error: {e}")
+                print(f"Retrying {retry_num}...")
+                time.sleep(5)
+                if retry_num > 3:
+                    raise Exception(
+                        f"Failed to get data from CAISO. Error: {e}")
+
         df = df.pivot_table(index=['INTERVALSTARTTIME_GMT', 'NODE'],
-                            columns='LMP_TYPE', values='MW', aggfunc='first')
+                            columns='LMP_TYPE', values=PRICE_COL, aggfunc='first')
         df = df.reset_index().rename(columns={
-            "NODE": "pnode", "OPR_HR": "hour", "LMP": "lmp", "MCE": "energy", "MCC": "congestion", "MCL": "losses"})
-        df["interval start"] = pd.to_datetime(
-            df['INTERVALSTARTTIME_GMT']).dt.tz_convert(self.default_timezone)
-        df = df.set_index("interval start").drop(
-            columns=["INTERVALSTARTTIME_GMT"])
+            "INTERVALSTARTTIME_GMT": "Time", "NODE": "Node", "LMP": "LMP", "MCE": "Energy", "MCC": "Congestion", "MCL": "Loss"})
+        df["Time"] = pd.to_datetime(
+            df['Time']).dt.tz_convert(self.default_timezone)
+
+        df["Market"] = market
+
+        df = df[["Time", "Market", "Node", "LMP",
+                "Energy", "Congestion", "Loss"]]
 
         return df
 

--- a/isodata/caiso.py
+++ b/isodata/caiso.py
@@ -1,7 +1,7 @@
 from numpy import isin
 
 import isodata
-from .base import ISOBase, FuelMix, GridStatus
+from .base import ISOBase, FuelMix, GridStatus, Markets
 import pandas as pd
 from typing import Any
 
@@ -16,8 +16,8 @@ class CAISO(ISOBase):
     iso_id = "caiso"
     default_timezone = "US/Pacific"
 
-    DAY_AHEAD_HOURLY = "DAY_AHEAD_HOURLY"
-    REAL_TIME_15_MIN = "REAL_TIME_15_MIN"
+    DAY_AHEAD_HOURLY = Markets.DAY_AHEAD_HOURLY
+    REAL_TIME_15_MIN = Markets.REAL_TIME_15_MIN
 
     def _current_day(self):
         # get current date from stats api

--- a/isodata/caiso.py
+++ b/isodata/caiso.py
@@ -8,6 +8,7 @@ import requests
 from numpy import isin
 
 import isodata
+from isodata import utils
 from isodata.base import FuelMix, GridStatus, ISOBase, Markets
 
 
@@ -266,6 +267,8 @@ class CAISO(ISOBase):
         df["Market"] = market
 
         df = df[["Time", "Market", "Node", "LMP", "Energy", "Congestion", "Loss"]]
+
+        data = utils.filter_lmp_nodes(df, nodes)
 
         time.sleep(sleep)
 

--- a/isodata/ercot.py
+++ b/isodata/ercot.py
@@ -100,7 +100,9 @@ class Ercot(ISOBase):
 
     def get_prices(self):
         pass
+    # https://www.ercot.com/mktinfo
     # https://www.ercot.com/api/1/services/read/dashboards/systemWidePrices.json
+    # https://www.ercot.com/mp/data-products/markets/real-time-market?id=NP6-788-CD
 
     def _handle_data(self, df, columns):
         df["Time"] = pd.to_datetime(df["epoch"], unit="ms").dt.tz_localize(

--- a/isodata/isone.py
+++ b/isodata/isone.py
@@ -20,13 +20,36 @@ class ISONE(ISOBase):
     REAL_TIME_HOURLY = Markets.REAL_TIME_HOURLY
     DAY_AHEAD_HOURLY = Markets.DAY_AHEAD_HOURLY
 
+    hubs = {"H.INTERNAL_HUB": 4000}
+    zones = {
+        ".Z.MAINE": 4001,
+        ".Z.NEWHAMPSHIRE": 4002,
+        ".Z.VERMONT": 4003,
+        ".Z.CONNECTICUT": 4004,
+        ".Z.RHODEISLAND": 4005,
+        ".Z.SEMASS": 4006,
+        ".Z.WCMASS": 4007,
+        ".Z.NEMASSBOST": 4008,
+    }
+    interfaces = {
+        ".I.SALBRYNB345": 4010,
+        ".I.ROSETON 345": 4011,
+        ".I.HQ_P1_P2345": 4012,
+        ".I.HQHIGATE120": 4013,
+        ".I.SHOREHAM138": 4014,
+        ".I.NRTHPORT138": 4017,
+    }
+
     def get_latest_fuel_mix(self):
         r = requests.post(
             "https://www.iso-ne.com/ws/wsclient",
             data={"_nstmp_requestType": "fuelmix"},
         ).json()
         mix_df = pd.DataFrame(r[0]["data"]["GenFuelMixes"]["GenFuelMix"])
-        time = pd.Timestamp(mix_df["BeginDate"].max(), tz=self.default_timezone)
+        time = pd.Timestamp(
+            mix_df["BeginDate"].max(),
+            tz=self.default_timezone,
+        )
 
         # todo has marginal flag
         mix_dict = mix_df.set_index("FuelCategory")["GenMw"].to_dict()
@@ -99,7 +122,10 @@ class ISONE(ISOBase):
             "_nstmp_inclBtmPv": True,
         }
 
-        r = requests.post("https://www.iso-ne.com/ws/wsclient", data=data).json()
+        r = requests.post(
+            "https://www.iso-ne.com/ws/wsclient",
+            data=data,
+        ).json()
 
         data = pd.DataFrame(r[0]["data"]["actual"])
 
@@ -130,6 +156,9 @@ class ISONE(ISOBase):
         return self._supply_from_fuel_mix(date)
 
     def get_latest_lmp(self, market: str, nodes: list):
+        """
+        Find Node ID mapping: https://www.iso-ne.com/markets-operations/settlements/pricing-node-tables/
+        """
         # todo optimize to read latest csv
         if market == self.REAL_TIME_5_MIN:
             url = "https://www.iso-ne.com/transform/csv/fiveminlmp/current?type=prelim"
@@ -161,6 +190,7 @@ class ISONE(ISOBase):
         return self._yesterday_from_historical(self.get_historical_lmp, market, nodes)
 
     def get_historical_lmp(self, date, market: str, nodes: list):
+        """Find Node ID mapping: https://www.iso-ne.com/markets-operations/settlements/pricing-node-tables/"""
         date = isodata.utils._handle_date(date)
         date_str = date.strftime("%Y%m%d")
 
@@ -191,7 +221,13 @@ class ISONE(ISOBase):
 
             data = pd.concat(dfs)
 
-            data["Local Time"] = date.strftime("%Y-%m-%d") + " " + data["Local Time"]
+            data["Local Time"] = (
+                date.strftime(
+                    "%Y-%m-%d",
+                )
+                + " "
+                + data["Local Time"]
+            )
 
             # add current interval
             if now.date() == date.date():
@@ -288,6 +324,16 @@ def _process_lmp(data, market, timezone):
 
     data["Time"] = pd.to_datetime(data["Time"]).dt.tz_localize(timezone)
 
-    data = data[["Time", "Market", "Node", "LMP", "Energy", "Congestion", "Loss"]]
+    data = data[
+        [
+            "Time",
+            "Market",
+            "Node",
+            "LMP",
+            "Energy",
+            "Congestion",
+            "Loss",
+        ]
+    ]
 
     return data

--- a/isodata/isone.py
+++ b/isodata/isone.py
@@ -8,6 +8,7 @@ import pandas as pd
 import requests
 
 import isodata
+from isodata import utils
 from isodata.base import FuelMix, ISOBase, Markets
 
 
@@ -178,7 +179,7 @@ class ISONE(ISOBase):
         else:
             raise RuntimeError("Unsupported market")
 
-        data = _process_lmp(data, market, self.default_timezone)
+        data = _process_lmp(data, market, self.default_timezone, nodes)
         return data
 
     def get_lmp_today(self, market: str, nodes: list):
@@ -268,7 +269,7 @@ class ISONE(ISOBase):
         else:
             raise RuntimeError("Unsupported market")
 
-        data = _process_lmp(data, market, self.default_timezone)
+        data = _process_lmp(data, market, self.default_timezone, nodes)
 
         return data
 
@@ -304,7 +305,7 @@ def _make_request(url, skiprows):
         return df
 
 
-def _process_lmp(data, market, timezone):
+def _process_lmp(data, market, timezone, nodes):
     # todo handle location types
     rename = {
         "Location ID": "Node",
@@ -336,4 +337,5 @@ def _process_lmp(data, market, timezone):
         ]
     ]
 
+    data = utils.filter_lmp_nodes(data, nodes)
     return data

--- a/isodata/miso.py
+++ b/isodata/miso.py
@@ -11,6 +11,9 @@ class MISO(ISOBase):
     # says EST in time stamp but EDT is currently in affect. EST == CDT, so using central time for now
     default_timezone = "US/Central"
 
+    REAL_TIME_5_MIN = "REAL_TIME_5_MIN"
+    DAY_AHEAD_HOURLY = "DAY_AHEAD_HOURLY"
+
     def __init__(self) -> None:
         super().__init__()
 
@@ -62,5 +65,54 @@ class MISO(ISOBase):
         df = df.rename(columns={"Value": "Demand"})
         return df
 
-    # market reports https://www.misoenergy.org/markets-and-operations/real-time--market-data/market-reports/#nt=
-    # historical fuel mix: https://www.misoenergy.org/markets-and-operations/real-time--market-data/market-reports/#nt=%2FMarketReportType%3ASummary%2FMarketReportName%3AHistorical%20Generation%20Fuel%20Mix%20(xlsx)&t=10&p=0&s=MarketReportPublished&sd=desc
+    def get_latest_lmp(self, market: str, nodes: list):
+        """
+            Supported Markets: REAL_TIME_5_MIN, DAY_AHEAD_HOURLY
+        """
+        url = "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=getLMPConsolidatedTable&returnType=json"
+        r = self._get_json(url)
+
+        time = r["LMPData"]["RefId"]
+        time_str = time[:11] + " " + time[-9:]
+        time = pd.to_datetime(time_str).tz_localize(self.default_timezone)
+        if market == self.REAL_TIME_5_MIN:
+            data = pd.DataFrame(r["LMPData"]["FiveMinLMP"]["PricingNode"])
+
+        elif market == self.DAY_AHEAD_HOURLY:
+            data = pd.DataFrame(
+                r["LMPData"]["DayAheadExPostLMP"]["PricingNode"])
+            time = time.ceil("H")
+
+        rename = {
+            "name": "Node",
+            "LMP": "LMP",
+            "MLC": "Loss",
+            "MCC": "Congestion",
+        }
+
+        data.rename(columns=rename, inplace=True)
+
+        data[["LMP", "Loss", "Congestion"]] = data[["LMP", "Loss",
+                                                    "Congestion"]].apply(pd.to_numeric, errors='coerce')
+
+        data["Energy"] = data["LMP"] - data["Loss"] - data["Congestion"]
+        data["Time"] = time
+        data["Market"] = market
+
+        data = data[["Time", "Market", "Node", "LMP",
+                     "Energy", "Congestion", "Loss"]]
+
+        return data
+
+
+        # market reports https://www.misoenergy.org/markets-and-operations/real-time--market-data/market-reports/#nt=
+        # historical fuel mix: https://www.misoenergy.org/markets-and-operations/real-time--market-data/market-reports/#nt=%2FMarketReportType%3ASummary%2FMarketReportName%3AHistorical%20Generation%20Fuel%20Mix%20(xlsx)&t=10&p=0&s=MarketReportPublished&sd=desc
+"""
+# Real time data of hub
+https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=getExAnteLMP&returnType=json
+
+
+# real time 5 minute lmp
+https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=getLMPConsolidatedTable&returnType=json
+
+"""

--- a/isodata/nyiso.py
+++ b/isodata/nyiso.py
@@ -133,10 +133,6 @@ class NYISO(ISOBase):
             marketname = "damlbmp"
             filename = marketname + "_zone"
 
-        if market == self.REAL_TIME_5_MIN:
-            marketname = "realtime"
-            filename = marketname + "_zone"
-
         df = _download_nyiso_archive(date, market_name=marketname, filename=filename)
 
         # todo handle node

--- a/isodata/nyiso.py
+++ b/isodata/nyiso.py
@@ -1,6 +1,6 @@
 import pdb
 import requests
-from .base import ISOBase, FuelMix
+from .base import ISOBase, FuelMix, Markets
 import pandas as pd
 import isodata
 import io
@@ -13,8 +13,8 @@ class NYISO(ISOBase):
     default_timezone = "US/Eastern"
 
     # Markets
-    REAL_TIME_5_MIN = "REAL_TIME_5_MIN"
-    DAY_AHEAD_5_MIN = "DAY_AHEAD_5_MIN"
+    REAL_TIME_5_MIN = Markets.REAL_TIME_5_MIN
+    DAY_AHEAD_5_MIN = Markets.DAY_AHEAD_5_MIN
 
     # def get_latest_status(self):
     #     # https://www.nyiso.com/en/system-conditions

--- a/isodata/nyiso.py
+++ b/isodata/nyiso.py
@@ -1,3 +1,4 @@
+import pdb
 import requests
 from .base import ISOBase, FuelMix
 import pandas as pd
@@ -10,6 +11,10 @@ class NYISO(ISOBase):
     name = "New York ISO"
     iso_id = "nyiso"
     default_timezone = "US/Eastern"
+
+    # Markets
+    REAL_TIME_5_MIN = "REAL_TIME_5_MIN"
+    DAY_AHEAD_5_MIN = "DAY_AHEAD_5_MIN"
 
     # def get_latest_status(self):
     #     # https://www.nyiso.com/en/system-conditions
@@ -66,6 +71,7 @@ class NYISO(ISOBase):
         demand = data.groupby("Time Stamp")[
             "Load"].sum().reset_index()
 
+        # TODO demand by zone
         demand = demand.rename(columns={"Time Stamp": "Time",
                                         "Load": "Demand"})
 
@@ -93,20 +99,76 @@ class NYISO(ISOBase):
         """Returns supply at a previous date in 5 minute intervals"""
         return self._supply_from_fuel_mix(date)
 
-    # def get_real_time_prices(self, )
-    # def get_day_ahead_prices(self,)
+    def get_latest_lmp(self, market: str, nodes: list):
+        return self._latest_lmp_from_today(market, nodes, node_column="Zone")
 
-    # https://www.nyiso.com/energy-market-operational-data
+    def get_lmp_today(self, market: str, nodes: list):
+        "Get lmp for today in 5 minute intervals"
+        return self._today_from_historical(self.get_historical_lmp, market, nodes)
+
+    def get_lmp_yesterday(self, market: str, nodes: list):
+        "Get lmp for yesterday in 5 minute intervals"
+        return self._yesterday_from_historical(self.get_historical_lmp, market, nodes)
+
+    def get_historical_lmp(self, date, market: str, nodes: list):
+        """
+        Supported Markets: REAL_TIME_5_MIN, DAY_AHEAD_5_MIN
+        """
+        # todo support generator and zone
+        if market == self.REAL_TIME_5_MIN:
+            marketname = "realtime"
+            filename = marketname + "_zone"
+        if market == self.DAY_AHEAD_5_MIN:
+            marketname = "damlbmp"
+            filename = marketname + "_zone"
+
+        if market == self.REAL_TIME_5_MIN:
+            marketname = "realtime"
+            filename = marketname + "_zone"
+
+        df = _download_nyiso_archive(
+            date, market_name=marketname, filename=filename)
+
+        # todo handle node
+        columns = {
+            "Time Stamp": "Time",
+            "Name": "Zone",
+            'LBMP ($/MWHr)': "LMP",
+            "Marginal Cost Losses ($/MWHr)": "Loss",
+            'Marginal Cost Congestion ($/MWHr)': "Congestion",
+        }
+
+        df = df.rename(columns=columns)
+
+        df["Energy"] = df["LMP"] - (df["Loss"] - df["Congestion"])
+        df["Market"] = market
+
+        df = df[["Time", "Market", "Zone", "LMP",
+                "Energy", "Congestion", "Loss"]]
+
+        df["Time"] = pd.to_datetime(
+            df["Time"]).dt.tz_localize(self.default_timezone)
+
+        return df
 
 
-def _download_nyiso_archive(date, filename):
+# def get_day_ahead_prices(self,)
+
+# https://www.nyiso.com/energy-market-operational-data
+
+
+def _download_nyiso_archive(date, market_name, filename=None):
+
+    if filename is None:
+        filename = market_name
+
     date = isodata.utils._handle_date(date)
     month = date.strftime('%Y%m01')
     day = date.strftime('%Y%m%d')
 
-    file = f"{day}{filename}.csv"
-    csv_url = f'http://mis.nyiso.com/public/csv/{filename}/{file}'
-    zip_url = f'http://mis.nyiso.com/public/csv/{filename}/{month}{filename}_csv.zip'
+    csv_filename = f"{day}{filename}.csv"
+    csv_url = f'http://mis.nyiso.com/public/csv/{market_name}/{csv_filename}'
+    zip_url = f'http://mis.nyiso.com/public/csv/{market_name}/{month}{filename}_csv.zip'
 
     # the last 7 days of file are hosted directly as csv
     try:
@@ -114,7 +176,7 @@ def _download_nyiso_archive(date, filename):
     except:
         r = requests.get(zip_url)
         z = ZipFile(io.BytesIO(r.content))
-        df = pd.read_csv(z.open(file))
+        df = pd.read_csv(z.open(csv_filename))
 
     return df
 

--- a/isodata/nyiso.py
+++ b/isodata/nyiso.py
@@ -6,6 +6,7 @@ import pandas as pd
 import requests
 
 import isodata
+from isodata import utils
 from isodata.base import FuelMix, ISOBase, Markets
 
 
@@ -152,6 +153,8 @@ class NYISO(ISOBase):
         df = df[["Time", "Market", "Zone", "LMP", "Energy", "Congestion", "Loss"]]
 
         df["Time"] = pd.to_datetime(df["Time"]).dt.tz_localize(self.default_timezone)
+
+        data = utils.filter_lmp_nodes(df, nodes, node_column="Zone")
 
         return df
 

--- a/isodata/pjm.py
+++ b/isodata/pjm.py
@@ -80,6 +80,7 @@ class PJM(ISOBase):
         return self._yesterday_from_historical(self.get_historical_demand)
 
     def get_historical_demand(self, date):
+        # can support a load area
         date = date = isodata.utils._handle_date(date)
         tomorrow = date + pd.DateOffset(1)
 
@@ -117,6 +118,13 @@ class PJM(ISOBase):
             "https://dataminer2.pjm.com/config/settings.json")
 
         return settings["subscriptionKey"]
+
+    # def get_historical_lmp(self, date, market: str, nodes: list):
+        # doesn't have current day
+        # REAL_TIME_5_MIN = "REAL_TIME_5_MIN"
+        # https://dataminer2.pjm.com/feed/rt_fivemin_hrl_lmps
+        # REAL_TIME_HOURLY = "REAL_TIME_HOURLY"
+        # https://dataminer2.pjm.com/feed/rt_hrl_lmps
 
 
 """

--- a/isodata/spp.py
+++ b/isodata/spp.py
@@ -1,3 +1,4 @@
+from turtle import st
 from .base import ISOBase, FuelMix
 import pandas as pd
 
@@ -46,7 +47,16 @@ class SPP(ISOBase):
         }).dropna(subset=["Demand"])
 
         return df
-# historical generation mix
-# https://marketplace.spp.org/pages/generation-mix-rolling-365
-# https://marketplace.spp.org/chart-api/gen-mix-365/asFile
-# 15mb file with five minute resolution
+
+        # todo where does date got in argument order
+        # def get_historical_lmp(self, date, market: str, nodes: list):
+        # 5 minute interal data
+        # https://marketplace.spp.org/file-browser-api/download/rtbm-lmp-by-location?path=/2022/08/By_Interval/08/RTBM-LMP-SL-202208082125.csv
+
+        # hub and interface prices
+        # https://marketplace.spp.org/pages/hub-and-interface-prices
+
+        # historical generation mix
+        # https://marketplace.spp.org/pages/generation-mix-rolling-365
+        # https://marketplace.spp.org/chart-api/gen-mix-365/asFile
+        # 15mb file with five minute resolution

--- a/isodata/tests/test_isos.py
+++ b/isodata/tests/test_isos.py
@@ -138,7 +138,7 @@ def test_get_historical_demand(iso):
     assert df.loc[0]["Time"].strftime('%Y%m%d') == date_obj.strftime('%Y%m%d')
 
     # datetime object works
-    date_obj = pd.to_datetime("2022/07/09").date()
+    date_obj = pd.to_datetime("2022/07/10").date()
     df = iso.get_historical_demand(date_obj)
     assert isinstance(df, pd.DataFrame)
     assert set(["Time", "Demand"]) == set(df.columns)
@@ -219,12 +219,12 @@ def test_get_latest_lmp(test):
 
 
 @pytest.mark.parametrize('test', [
-    # {
-    #     CAISO(): {
-    #         "markets": [CAISO.DAY_AHEAD_HOURLY, CAISO.REAL_TIME_15_MIN],
-    #         "nodes": None
-    #     },
-    # },
+    {
+        CAISO(): {
+            "markets": [CAISO.REAL_TIME_15_MIN],
+            "nodes": None
+        },
+    },
     {
         ISONE(): {
             "markets": [ISONE.DAY_AHEAD_HOURLY, ISONE.REAL_TIME_5_MIN],

--- a/isodata/tests/test_isos.py
+++ b/isodata/tests/test_isos.py
@@ -170,7 +170,11 @@ def test_get_historical_demand(iso):
     [
         {
             CAISO(): {
-                "markets": [CAISO.DAY_AHEAD_HOURLY, CAISO.REAL_TIME_15_MIN],
+                "markets": [
+                    CAISO.REAL_TIME_HOURLY,
+                    CAISO.DAY_AHEAD_HOURLY,
+                    CAISO.REAL_TIME_15_MIN,
+                ],
                 "nodes": None,
             },
         },
@@ -208,7 +212,11 @@ def test_get_historical_lmp(test):
     [
         {
             CAISO(): {
-                "markets": [CAISO.DAY_AHEAD_HOURLY, CAISO.REAL_TIME_15_MIN],
+                "markets": [
+                    CAISO.REAL_TIME_HOURLY,
+                    CAISO.DAY_AHEAD_HOURLY,
+                    CAISO.REAL_TIME_15_MIN,
+                ],
                 "nodes": None,
             },
         },
@@ -248,7 +256,14 @@ def test_get_latest_lmp(test):
     "test",
     [
         {
-            CAISO(): {"markets": [CAISO.REAL_TIME_15_MIN], "nodes": None},
+            CAISO(): {
+                "markets": [
+                    CAISO.REAL_TIME_HOURLY,
+                    CAISO.REAL_TIME_15_MIN,
+                    CAISO.DAY_AHEAD_HOURLY,
+                ],
+                "nodes": None,
+            },
         },
         {
             ISONE(): {

--- a/isodata/tests/test_isos.py
+++ b/isodata/tests/test_isos.py
@@ -139,3 +139,77 @@ def test_get_historical_demand(iso):
     assert isinstance(df, pd.DataFrame)
     assert set(["Time", "Demand"]) == set(df.columns)
     assert df.loc[0]["Time"].strftime('%Y%m%d') == date_obj.strftime('%Y%m%d')
+
+
+@pytest.mark.parametrize('test', [
+    # {
+    #     CAISO(): {
+    #         "markets": [CAISO.DAY_AHEAD_HOURLY, CAISO.REAL_TIME_15_MIN],
+    #         "nodes": None
+    #     },
+    # },
+    {
+        ISONE(): {
+            "markets": [ISONE.REAL_TIME_HOURLY],  # , ISONE.REAL_TIME_5_MIN
+            "nodes": "ALL"
+        }
+    },
+    {
+        NYISO(): {
+            "markets": [NYISO.DAY_AHEAD_5_MIN, NYISO.REAL_TIME_5_MIN],
+            "nodes": "ALL"
+        }
+    }
+])
+def test_get_historical_lmp(test):
+    iso = list(test)[0]
+    markets = test[iso]["markets"]
+    nodes = test[iso]["nodes"]
+
+    date_str = "20220722"
+    for m in markets:
+        print(iso.iso_id, m)
+        hist = iso.get_historical_lmp(date_str, m, nodes=nodes)
+        assert isinstance(hist, pd.DataFrame)
+        today = iso.get_lmp_today(m, nodes=nodes)
+        assert isinstance(today, pd.DataFrame)
+        # yesterday = iso.get_lmp_yesterday(m, nodes=nodes)
+        # assert isinstance(yesterday, pd.DataFrame)
+
+
+@pytest.mark.parametrize('test', [
+    # {
+    #     CAISO(): {
+    #         "markets": [CAISO.DAY_AHEAD_HOURLY, CAISO.REAL_TIME_15_MIN],
+    #         "nodes": None
+    #     },
+    # },
+    {
+        ISONE(): {
+            "markets": [ISONE.REAL_TIME_5_MIN, ISONE.REAL_TIME_HOURLY],
+            "nodes": "ALL"
+        }
+    },
+    {
+        MISO(): {
+            "markets": [MISO.REAL_TIME_5_MIN, MISO.DAY_AHEAD_HOURLY],
+            "nodes": "ALL"
+        }
+    },
+    {
+        NYISO(): {
+            "markets": [NYISO.DAY_AHEAD_5_MIN, NYISO.REAL_TIME_5_MIN],
+            "nodes": "ALL"
+        }
+    }
+])
+def test_get_latest_lmp(test):
+    iso = list(test)[0]
+    markets = test[iso]["markets"]
+    nodes = test[iso]["nodes"]
+
+    date_str = "20220722"
+    for m in markets:
+        print(iso.iso_id, m)
+        latest = iso.get_latest_lmp(m, nodes=nodes)
+        assert isinstance(latest, pd.DataFrame)

--- a/isodata/tests/test_isos.py
+++ b/isodata/tests/test_isos.py
@@ -7,6 +7,10 @@ import pytest
 all_isos = [MISO(), CAISO(), PJM(), Ercot(), SPP(), NYISO(), ISONE()]
 
 
+def test_make_lmp_availability_df():
+    isodata.utils.make_lmp_availability_table()
+
+
 @pytest.mark.parametrize('iso', all_isos)
 def test_get_latest_fuel_mix(iso):
     print(iso)
@@ -150,7 +154,8 @@ def test_get_historical_demand(iso):
     # },
     {
         ISONE(): {
-            "markets": [ISONE.REAL_TIME_HOURLY],  # , ISONE.REAL_TIME_5_MIN
+            # , ISONE.REAL_TIME_5_MIN
+            "markets": [ISONE.DAY_AHEAD_HOURLY, ISONE.REAL_TIME_HOURLY],
             "nodes": "ALL"
         }
     },
@@ -171,10 +176,8 @@ def test_get_historical_lmp(test):
         print(iso.iso_id, m)
         hist = iso.get_historical_lmp(date_str, m, nodes=nodes)
         assert isinstance(hist, pd.DataFrame)
-        today = iso.get_lmp_today(m, nodes=nodes)
-        assert isinstance(today, pd.DataFrame)
-        # yesterday = iso.get_lmp_yesterday(m, nodes=nodes)
-        # assert isinstance(yesterday, pd.DataFrame)
+        yesterday = iso.get_lmp_yesterday(m, nodes=nodes)
+        assert isinstance(yesterday, pd.DataFrame)
 
 
 @pytest.mark.parametrize('test', [
@@ -213,3 +216,33 @@ def test_get_latest_lmp(test):
         print(iso.iso_id, m)
         latest = iso.get_latest_lmp(m, nodes=nodes)
         assert isinstance(latest, pd.DataFrame)
+
+
+@pytest.mark.parametrize('test', [
+    # {
+    #     CAISO(): {
+    #         "markets": [CAISO.DAY_AHEAD_HOURLY, CAISO.REAL_TIME_15_MIN],
+    #         "nodes": None
+    #     },
+    # },
+    {
+        ISONE(): {
+            "markets": [ISONE.DAY_AHEAD_HOURLY, ISONE.REAL_TIME_5_MIN],
+            "nodes": "ALL"
+        }
+    },
+    {
+        NYISO(): {
+            "markets": [NYISO.DAY_AHEAD_5_MIN, NYISO.REAL_TIME_5_MIN],
+            "nodes": "ALL"
+        }
+    }
+])
+def test_get_latest_lmp(test):
+    iso = list(test)[0]
+    markets = test[iso]["markets"]
+    nodes = test[iso]["nodes"]
+
+    for m in markets:
+        today = iso.get_lmp_today(m, nodes=nodes)
+        assert isinstance(today, pd.DataFrame)

--- a/isodata/tests/test_isos.py
+++ b/isodata/tests/test_isos.py
@@ -146,12 +146,12 @@ def test_get_historical_demand(iso):
 
 
 @pytest.mark.parametrize('test', [
-    # {
-    #     CAISO(): {
-    #         "markets": [CAISO.DAY_AHEAD_HOURLY, CAISO.REAL_TIME_15_MIN],
-    #         "nodes": None
-    #     },
-    # },
+    {
+        CAISO(): {
+            "markets": [CAISO.DAY_AHEAD_HOURLY, CAISO.REAL_TIME_15_MIN],
+            "nodes": None
+        },
+    },
     {
         ISONE(): {
             # , ISONE.REAL_TIME_5_MIN
@@ -181,12 +181,12 @@ def test_get_historical_lmp(test):
 
 
 @pytest.mark.parametrize('test', [
-    # {
-    #     CAISO(): {
-    #         "markets": [CAISO.DAY_AHEAD_HOURLY, CAISO.REAL_TIME_15_MIN],
-    #         "nodes": None
-    #     },
-    # },
+    {
+        CAISO(): {
+            "markets": [CAISO.DAY_AHEAD_HOURLY, CAISO.REAL_TIME_15_MIN],
+            "nodes": None
+        },
+    },
     {
         ISONE(): {
             "markets": [ISONE.REAL_TIME_5_MIN, ISONE.REAL_TIME_HOURLY],
@@ -238,7 +238,7 @@ def test_get_latest_lmp(test):
         }
     }
 ])
-def test_get_latest_lmp(test):
+def test_get_lmp_today(test):
     iso = list(test)[0]
     markets = test[iso]["markets"]
     nodes = test[iso]["nodes"]

--- a/isodata/utils.py
+++ b/isodata/utils.py
@@ -96,3 +96,10 @@ def make_lmp_availability_table():
 
     s = pd.Series(a, name="Markets")
     return s.to_markdown()
+
+
+def filter_lmp_nodes(data, nodes: list, node_column: str = "Node"):
+    if nodes == "ALL":
+        return data
+
+    return data[data[node_column].isin(nodes)]

--- a/isodata/utils.py
+++ b/isodata/utils.py
@@ -9,6 +9,8 @@ from isodata.miso import MISO
 from isodata.spp import SPP
 from isodata.pjm import PJM
 
+from datetime import datetime
+
 all_isos = [MISO, CAISO, PJM, Ercot, SPP, NYISO, ISONE]
 
 
@@ -64,8 +66,11 @@ def make_availability_table():
     return df.to_markdown()
 
 
-def _handle_date(date):
-    if isinstance(date, str):
+def _handle_date(date, tz=None):
+    if not isinstance(date, pd.Timestamp):
         date = pd.to_datetime(date)
+
+    if tz and date.tzinfo is None:
+        date = date.tz_localize(tz)
 
     return date

--- a/isodata/utils.py
+++ b/isodata/utils.py
@@ -1,5 +1,5 @@
 import isodata
-from isodata.base import ISOBase
+from isodata.base import ISOBase, Markets
 import pandas as pd
 from isodata.nyiso import NYISO
 from isodata.caiso import CAISO
@@ -74,3 +74,24 @@ def _handle_date(date, tz=None):
         date = date.tz_localize(tz)
 
     return date
+
+
+def make_lmp_availability():
+    lmp_availability = {}
+    for i in all_isos:
+        lmp_availability[i.name] = []
+        for m in Markets:
+            if hasattr(i, m.name):
+                lmp_availability[i.name].append(m.name)
+
+    return lmp_availability
+
+
+def make_lmp_availability_table():
+    a = make_lmp_availability()
+    for iso in a:
+        a[iso] = ["`"+v+"`" for v in a[iso]]
+        a[iso] = ", ".join(a[iso])
+
+    s = pd.Series(a, name="Markets")
+    return s.to_markdown()

--- a/update_readme.py
+++ b/update_readme.py
@@ -1,15 +1,24 @@
 import isodata
+from isodata.utils import make_availability_table, make_lmp_availability_table
 
-start_str = '<!-- METHOD AVAILABILITY TABLE START -->'
-end_str = '<!-- METHOD AVAILABILITY TABLE END -->'
 
-with open('README.md', 'r+') as f:
-    content = f.read()
-    start = content.index(start_str) + len(start_str)
-    end = content.index(end_str)
-    new_content = content[:start] + "\n" + \
-        isodata.make_availability_table() + "\n" + content[end:]
+def insert_readme(start_str, end_str, to_insert):
+    with open('README.md', 'r+') as f:
+        content = f.read()
+        insert_start = content.index(start_str) + len(start_str)
+        insert_end = content.index(end_str)
+        new_file_content = content[:insert_start] + "\n" + \
+            to_insert + "\n" + content[insert_end:]
 
-    f.seek(0)
-    f.write(new_content)
-    f.truncate()
+        f.seek(0)
+        f.write(new_file_content)
+        f.truncate()
+
+
+insert_readme('<!-- METHOD AVAILABILITY TABLE START -->',
+              '<!-- METHOD AVAILABILITY TABLE END -->',
+              make_availability_table())
+
+insert_readme('<!-- LMP AVAILABILITY TABLE START -->',
+              '<!-- LMP AVAILABILITY TABLE END -->',
+              make_lmp_availability_table())


### PR DESCRIPTION
Add real time and day ahead lmp markets

Status: in-progress

## LMP Pricing Data

We are currently adding Locational Marginal Price (LMP). Even though each BA offers different markets, you can query them with a standardized API

```python
>>> import isodata
>>> iso = isodata.NYISO()
>>> iso.get_lmp_today(iso.REAL_TIME_5_MIN, nodes="ALL")
```

```
                          Time           Market    Zone     LMP  Energy  Congestion  Losses
0    2022-08-08 00:05:00-04:00  REAL_TIME_5_MIN  CAPITL  125.15   90.63      -26.64    7.88
1    2022-08-08 00:05:00-04:00  REAL_TIME_5_MIN  CENTRL   92.17   90.63        0.00    1.54
2    2022-08-08 00:05:00-04:00  REAL_TIME_5_MIN  DUNWOD   99.52   90.63        0.00    8.89
3    2022-08-08 00:05:00-04:00  REAL_TIME_5_MIN  GENESE   92.53   90.62        0.00    1.91
4    2022-08-08 00:05:00-04:00  REAL_TIME_5_MIN     H Q   88.09   90.63        0.00   -2.54
...                        ...              ...     ...     ...     ...         ...     ...
3970 2022-08-08 22:00:00-04:00  REAL_TIME_5_MIN   NORTH  110.17  120.71        7.04   -3.50
3971 2022-08-08 22:00:00-04:00  REAL_TIME_5_MIN     NPX  236.60  120.72     -107.18    8.70
3972 2022-08-08 22:00:00-04:00  REAL_TIME_5_MIN     O H  121.23  120.72       -4.49   -3.98
3973 2022-08-08 22:00:00-04:00  REAL_TIME_5_MIN     PJM  146.13  120.71      -20.23    5.19
3974 2022-08-08 22:00:00-04:00  REAL_TIME_5_MIN    WEST  125.26  120.72       -5.02   -0.48

[3975 rows x 7 columns]
```

And here is querying CAISO

```
>>> import isodata
>>> iso = isodata.CAISO()
>>> iso.get_lmp_today(iso.DAY_AHEAD_HOURLY, nodes=None)
```

## Add Support for following LMP Markets

|                                       | Markets                                                    |
|:--------------------------------------|:-----------------------------------------------------------|
| Midcontinent ISO                      | `REAL_TIME_5_MIN`, `DAY_AHEAD_HOURLY`                      |
| California ISO                        | `REAL_TIME_15_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY` |
| PJM                                   |                                                            |
| Electric Reliability Council of Texas |                                                            |
| Southwest Power Pool                  |                                                            |
| New York ISO                          | `REAL_TIME_5_MIN`, `DAY_AHEAD_5_MIN`                       |
| ISO New England                       | `REAL_TIME_5_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY`  |