### PR TITLE
Better linting setup, fix pyproject.toml requires, add pre-commit

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,26 @@
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches:
+      - main
+
+name: Lint Check
+jobs:
+  lint_test:
+    name: 3.10 lint check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.10
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Build package
+        run: make package
+      - name: Install package with dev deps
+        run: |
+          python -m pip install -e ".[dev]"
+      - name: Run lint test
+        run: make lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,8 +17,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.10'
-      - name: Build package
-        run: make package
       - name: Install package with dev deps
         run: |
           python -m pip install -e ".[dev]"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,12 +11,12 @@ jobs:
     name: 3.10 lint check
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
       - name: Set up python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
-      - name: Checkout repository
-        uses: actions/checkout@v2
+          python-version: '3.10'
       - name: Build package
         run: make package
       - name: Install package with dev deps

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,3 +22,9 @@ jobs:
           python -m pip install -e ".[dev]"
       - name: Run lint test
         run: make lint
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: PyPI Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: PyPI Upload
         uses: FeatureLabs/gh-action-pypi-upload@v2
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,15 +17,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install flake8 pytest
-          pip install .
-      - name: Lint with flake8
+          python -m pip install ".[test]"
+      - name: Run unit tests
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Test with pytest
-        run: |
-          pytest
+          make test

--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,3 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+exclude: ^LICENSE/|\.(html|csv|svg|md)$
+default_stages: [commit]
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,8 @@ repos:
     hooks:
       - id: absolufy-imports
         files: ^isodata/
+  - repo: https://github.com/asottile/add-trailing-comma
+    rev: v2.2.3
+    hooks:
+      - id: add-trailing-comma
+        name: Add trailing comma

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,7 @@ repos:
     hooks:
       - id: add-trailing-comma
         name: Add trailing comma
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,8 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/MarcoGorelli/absolufy-imports
+    rev: v0.3.1
+    hooks:
+      - id: absolufy-imports
+        files: ^isodata/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,9 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
+  - repo: https://github.com/python/black
+    rev: 22.6.0
+    hooks:
+      - id: black
+        args: [--target-version=py310]
+        types_or: [python]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,32 @@
 .PHONY: test
 test:
-	pytest isodata/
+	pytest -s -vv isodata/
+
+.PHONY: installdeps-dev
+installdeps-dev:
+	python -m pip install ".[dev]"
+
+.PHONY: lint
+lint:
+	python -m isort --check-only isodata
+	python -m black isodata -t py310 --check
+
+.PHONY: lint-fix
+lint-fix:
+	python -m black isodata -t py310
+	python -m isort isodata
+
+.PHONY: upgradepip
+upgradepip:
+	python -m pip install --upgrade pip
+
+.PHONY: upgradebuild
+upgradebuild:
+	python -m pip install --upgrade build
+
+.PHONY: package
+package: upgradepip upgradebuild
+	python -m build
+	$(eval PACKAGE=$(shell python -c "from pep517.meta import load; metadata = load('.'); print(metadata.version)"))
+	tar -zxvf "dist/isodata-${PACKAGE}.tar.gz"
+	mv "isodata-${PACKAGE}" unpacked

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	pytest -s -vv isodata/
+	python -m pytest -s -vv isodata/
 
 .PHONY: installdeps-dev
 installdeps-dev:
@@ -9,13 +9,13 @@ installdeps-dev:
 
 .PHONY: lint
 lint:
-	isort --check-only isodata
-	black isodata -t py310 --check
+	isort --check-only isodata/
+	black isodata/ -t py310 --check
 
 .PHONY: lint-fix
 lint-fix:
-	black isodata -t py310
-	isort isodata
+	black isodata/ -t py310
+	isort isodata/
 
 .PHONY: upgradepip
 upgradepip:

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,17 @@ test:
 .PHONY: installdeps-dev
 installdeps-dev:
 	python -m pip install ".[dev]"
+	pre-commit install
 
 .PHONY: lint
 lint:
-	python -m isort --check-only isodata
-	python -m black isodata -t py310 --check
+	isort --check-only isodata
+	black isodata -t py310 --check
 
 .PHONY: lint-fix
 lint-fix:
-	python -m black isodata -t py310
-	python -m isort isodata
+	black isodata -t py310
+	isort isodata
 
 .PHONY: upgradepip
 upgradepip:

--- a/isodata/__init__.py
+++ b/isodata/__init__.py
@@ -1,6 +1,7 @@
+from isodata.version import __version__
+
 from isodata.utils import list_isos, get_iso, make_availability_table
 from isodata import tests
-from isodata.version import __version__
 import isodata.base
 
 import isodata.utils

--- a/isodata/base.py
+++ b/isodata/base.py
@@ -1,12 +1,12 @@
 import pandas as pd
 import requests
 from tabulate import tabulate
+
 # TODO: this is needed to make SPP request work. restrict only to SPP
-requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS = 'ALL:@SECLEVEL=1'
+requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS = "ALL:@SECLEVEL=1"
 
 
 class ISOBase:
-
     def _get_json(self, *args, **kwargs):
         r = requests.get(*args, **kwargs)
         r = r.json()
@@ -64,8 +64,7 @@ class ISOBase:
         return method(today)
 
     def _yesterday_from_historical(self, method):
-        yesterday = (pd.Timestamp.now(self.default_timezone) -
-                     pd.DateOffset(1)).date()
+        yesterday = (pd.Timestamp.now(self.default_timezone) - pd.DateOffset(1)).date()
         return method(yesterday)
 
     def _supply_from_fuel_mix(self, date):
@@ -77,13 +76,10 @@ class ISOBase:
     def _latest_supply_from_fuel_mix(self):
         mix = self.get_latest_fuel_mix()
 
-        return {
-            "time": mix.time,
-            "supply": mix.total_production
-        }
+        return {"time": mix.time, "supply": mix.total_production}
 
 
-class GridStatus():
+class GridStatus:
     def __init__(self, time, status, reserves, iso, unit="MW") -> None:
         self.iso = iso
         self.time = time
@@ -107,15 +103,14 @@ class FuelMix:
         self.time = time
         self.unit = unit
 
-        mix_df = pd.Series(mix, name=self.unit).sort_values(
-            ascending=False).to_frame()
+        mix_df = pd.Series(mix, name=self.unit).sort_values(ascending=False).to_frame()
         mix_df["Percent"] = mix_df[self.unit] / mix_df[self.unit].sum() * 100
         mix_df.index.name = "Fuel"
         self._mix_df = mix_df
 
     def __repr__(self) -> str:
         # TODO sort by magnitude
-        s = ''
+        s = ""
         if self.iso:
             s += "ISO: " + self.iso + "\n"
         s += "Total Production: %d %s \n" % (self.total_production, self.unit)
@@ -123,15 +118,15 @@ class FuelMix:
 
         mix = self.mix
         mix["Percent"] = mix["Percent"].round(1)
-        s += tabulate(mix, headers='keys', tablefmt='psql')
+        s += tabulate(mix, headers="keys", tablefmt="psql")
 
         return s
 
-    @ property
+    @property
     def total_production(self):
         return self.mix[self.unit].sum()
 
-    @ property
+    @property
     def mix(self):
         return self._mix_df.copy()
 

--- a/isodata/ercot.py
+++ b/isodata/ercot.py
@@ -1,6 +1,8 @@
 from bdb import set_trace
-from .base import ISOBase, FuelMix, GridStatus
+
 import pandas as pd
+
+from isodata.base import FuelMix, GridStatus, ISOBase
 
 
 class Ercot(ISOBase):
@@ -13,8 +15,11 @@ class Ercot(ISOBase):
     def get_latest_status(self):
         r = self._get_json(self.BASE + "/daily-prc.json")
 
-        time = pd.to_datetime(r["current_condition"]["datetime"], unit="s").tz_localize(
-            "UTC").tz_convert(self.default_timezone)
+        time = (
+            pd.to_datetime(r["current_condition"]["datetime"], unit="s")
+            .tz_localize("UTC")
+            .tz_convert(self.default_timezone)
+        )
         status = r["current_condition"]["state"]
         reserves = float(r["current_condition"]["prc_value"].replace(",", ""))
         return GridStatus(time=time, status=status, reserves=reserves, iso=self.name)
@@ -23,10 +28,7 @@ class Ercot(ISOBase):
         df = self.get_fuel_mix_today()
         currentHour = df.iloc[-1]
 
-        mix_dict = {
-            "Wind": currentHour["Wind"],
-            "Solar": currentHour["Solar"]
-        }
+        mix_dict = {"Wind": currentHour["Wind"], "Solar": currentHour["Solar"]}
 
         return FuelMix(time=currentHour["Time"], mix=mix_dict, iso=self.name)
 
@@ -39,20 +41,16 @@ class Ercot(ISOBase):
         r = self._get_json(url)
 
         # rows with nulls are forecasts
-        df = pd.DataFrame(r['currentDay']["data"])
+        df = pd.DataFrame(r["currentDay"]["data"])
         df = df.dropna(subset=["actualSolar"])
 
-        df = self._handle_data(
-            df, {"actualSolar": "Solar", "actualWind": "Wind"})
+        df = self._handle_data(df, {"actualSolar": "Solar", "actualWind": "Wind"})
         return df
 
     def get_latest_demand(self):
-        d = self._get_demand('currentDay').iloc[-1]
+        d = self._get_demand("currentDay").iloc[-1]
 
-        return {
-            "time": d["Time"],
-            "demand": d["Demand"]
-        }
+        return {"time": d["Time"], "demand": d["Demand"]}
 
     def _get_demand(self, when):
         """Returns demand for currentDay or previousDay"""
@@ -80,31 +78,39 @@ class Ercot(ISOBase):
 
         Updates every 5 minutes
         """
-        url = 'https://www.ercot.com/api/1/services/read/dashboards/todays-outlook.json'
+        url = "https://www.ercot.com/api/1/services/read/dashboards/todays-outlook.json"
         r = self._get_json(url)
 
         date = pd.to_datetime(r["lastUpdated"][:10], format="%Y-%m-%d")
 
         # ignore last row since that corresponds to midnight following day
-        data = pd.DataFrame(r['data'][:-1])
+        data = pd.DataFrame(r["data"][:-1])
 
-        data["Time"] = pd.to_datetime(date.strftime("%Y-%m-%d") + " " + data["hourEnding"].astype(str).str.zfill(
-            2) + ":" + data["interval"].astype(str).str.zfill(2)).dt.tz_localize(self.default_timezone)
+        data["Time"] = pd.to_datetime(
+            date.strftime("%Y-%m-%d")
+            + " "
+            + data["hourEnding"].astype(str).str.zfill(2)
+            + ":"
+            + data["interval"].astype(str).str.zfill(2),
+        ).dt.tz_localize(self.default_timezone)
 
         data = data[data["forecast"] == 0]  # only keep non forecast rows
 
-        data = data[["Time", "capacity"]].rename(
-            columns={"capacity": "Supply"})
+        data = data[["Time", "capacity"]].rename(columns={"capacity": "Supply"})
 
         return data
 
     def get_prices(self):
         pass
+
     # https://www.ercot.com/api/1/services/read/dashboards/systemWidePrices.json
 
     def _handle_data(self, df, columns):
-        df["Time"] = pd.to_datetime(df["epoch"], unit="ms").dt.tz_localize(
-            "UTC").dt.tz_convert(self.default_timezone)
+        df["Time"] = (
+            pd.to_datetime(df["epoch"], unit="ms")
+            .dt.tz_localize("UTC")
+            .dt.tz_convert(self.default_timezone)
+        )
 
         cols_to_keep = ["Time"] + list(columns.keys())
         return df[cols_to_keep].rename(columns=columns)

--- a/isodata/isone.py
+++ b/isodata/isone.py
@@ -1,10 +1,12 @@
+import io
 import re
 from urllib import request
-from .base import ISOBase, FuelMix
+
 import pandas as pd
 import requests
+
 import isodata
-import io
+from isodata.base import FuelMix, ISOBase
 
 
 class ISONE(ISOBase):
@@ -13,11 +15,15 @@ class ISONE(ISOBase):
     default_timezone = "US/Eastern"
 
     def get_latest_fuel_mix(self):
-        r = requests.post("https://www.iso-ne.com/ws/wsclient",
-                          data={"_nstmp_requestType": "url", "_nstmp_requestUrl": "/genfuelmix/current"}).json()
-        mix_df = pd.DataFrame(r[0]['data']['GenFuelMixes']['GenFuelMix'])
-        time = pd.Timestamp(mix_df["BeginDate"].max(),
-                            tz=self.default_timezone)
+        r = requests.post(
+            "https://www.iso-ne.com/ws/wsclient",
+            data={
+                "_nstmp_requestType": "url",
+                "_nstmp_requestUrl": "/genfuelmix/current",
+            },
+        ).json()
+        mix_df = pd.DataFrame(r[0]["data"]["GenFuelMixes"]["GenFuelMix"])
+        time = pd.Timestamp(mix_df["BeginDate"].max(), tz=self.default_timezone)
 
         mix_dict = mix_df.set_index("FuelCategory")["GenMw"].to_dict()
         return FuelMix(time, mix_dict, self.name)
@@ -37,8 +43,9 @@ class ISONE(ISOBase):
         Provided at frequent, but irregular intervals by ISONE
         """
         date = isodata.utils._handle_date(date)
-        url = "https://www.iso-ne.com/transform/csv/genfuelmix?start=" + \
-            date.strftime('%Y%m%d')
+        url = "https://www.iso-ne.com/transform/csv/genfuelmix?start=" + date.strftime(
+            "%Y%m%d",
+        )
 
         with requests.Session() as s:
             # in testing, never takes more than 2 attempts
@@ -46,24 +53,34 @@ class ISONE(ISOBase):
             while attempt < 3:
                 # make first get request to get cookies set
                 r1 = s.get(
-                    "https://www.iso-ne.com/isoexpress/web/reports/operations/-/tree/gen-fuel-mix")
+                    "https://www.iso-ne.com/isoexpress/web/reports/operations/-/tree/gen-fuel-mix",
+                )
 
                 r2 = s.get(url)
 
                 if r2.status_code == 200:
                     break
 
-                print("Attempt {} failed. Retrying...".format(attempt+1))
+                print("Attempt {} failed. Retrying...".format(attempt + 1))
                 attempt += 1
 
-            df = pd.read_csv(io.StringIO(r2.content.decode("utf8")),
-                             skiprows=[0, 1, 2, 3, 5], skipfooter=1, engine='python')
+            df = pd.read_csv(
+                io.StringIO(r2.content.decode("utf8")),
+                skiprows=[0, 1, 2, 3, 5],
+                skipfooter=1,
+                engine="python",
+            )
 
-        df["Date"] = pd.to_datetime(
-            df['Date'] + ' ' + df['Time']).dt.tz_localize(self.default_timezone)
+        df["Date"] = pd.to_datetime(df["Date"] + " " + df["Time"]).dt.tz_localize(
+            self.default_timezone,
+        )
 
-        mix_df = df.pivot_table(index="Date", columns="Fuel Category",
-                                values="Gen Mw", aggfunc="first").reset_index()
+        mix_df = df.pivot_table(
+            index="Date",
+            columns="Fuel Category",
+            values="Gen Mw",
+            aggfunc="first",
+        ).reset_index()
 
         mix_df = mix_df.rename(columns={"Date": "Time"})
 
@@ -84,29 +101,32 @@ class ISONE(ISOBase):
         # _nstmp_formDate: 1659489137907
         date = isodata.utils._handle_date(date)
 
-        date_str = date.strftime('%m/%d/%Y')
-        data = {'_nstmp_startDate': date_str,
-                '_nstmp_endDate': date_str,
-                '_nstmp_twodays': False,
-                '_nstmp_twodaysCheckbox': False,
-                '_nstmp_requestType': "systemload",
-                '_nstmp_forecast': True,
-                '_nstmp_actual': True,
-                '_nstmp_cleared': True,
-                '_nstmp_priorDay': True,
-                '_nstmp_inclPumpLoad': True,
-                '_nstmp_inclBtmPv': True}
+        date_str = date.strftime("%m/%d/%Y")
+        data = {
+            "_nstmp_startDate": date_str,
+            "_nstmp_endDate": date_str,
+            "_nstmp_twodays": False,
+            "_nstmp_twodaysCheckbox": False,
+            "_nstmp_requestType": "systemload",
+            "_nstmp_forecast": True,
+            "_nstmp_actual": True,
+            "_nstmp_cleared": True,
+            "_nstmp_priorDay": True,
+            "_nstmp_inclPumpLoad": True,
+            "_nstmp_inclBtmPv": True,
+        }
 
-        r = requests.post(
-            "https://www.iso-ne.com/ws/wsclient", data=data).json()
+        r = requests.post("https://www.iso-ne.com/ws/wsclient", data=data).json()
 
         data = pd.DataFrame(r[0]["data"]["actual"])
 
-        data["BeginDate"] = pd.to_datetime(
-            data["BeginDate"]).dt.tz_convert(self.default_timezone)
+        data["BeginDate"] = pd.to_datetime(data["BeginDate"]).dt.tz_convert(
+            self.default_timezone,
+        )
 
         df = data[["BeginDate", "Mw"]].rename(
-            columns={"BeginDate": "Time", "Mw": "Demand"})
+            columns={"BeginDate": "Time", "Mw": "Demand"},
+        )
 
         return df
 

--- a/isodata/miso.py
+++ b/isodata/miso.py
@@ -1,6 +1,7 @@
-from pandas import Timestamp
 import pandas as pd
-from .base import ISOBase, FuelMix
+from pandas import Timestamp
+
+from isodata.base import FuelMix, ISOBase
 
 
 class MISO(ISOBase):
@@ -19,7 +20,8 @@ class MISO(ISOBase):
         r = self._get_json(url)
 
         time = pd.to_datetime(r["Fuel"]["Type"][0]["INTERVALEST"]).tz_localize(
-            self.default_timezone)
+            self.default_timezone,
+        )
 
         mix = {}
         for fuel in r["Fuel"]["Type"]:
@@ -39,8 +41,8 @@ class MISO(ISOBase):
         r = self._get_json(url)
 
         return {
-            "time": pd.to_datetime(r[1]['d']).tz_localize(self.default_timezone),
-            "demand": float(r[1]['v'].replace(",", ""))
+            "time": pd.to_datetime(r[1]["d"]).tz_localize(self.default_timezone),
+            "demand": float(r[1]["v"].replace(",", "")),
         }
 
     def get_latest_supply(self):
@@ -48,16 +50,17 @@ class MISO(ISOBase):
         return self._latest_supply_from_fuel_mix()
 
     def get_demand_today(self):
-        url = 'https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=gettotalload&returnType=json'
+        url = "https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=gettotalload&returnType=json"
         r = self._get_json(url)
 
         date = pd.to_datetime(r["LoadInfo"]["RefId"].split(" ")[0])
 
-        df = pd.DataFrame([x["Load"]
-                          for x in r["LoadInfo"]["FiveMinTotalLoad"]])
+        df = pd.DataFrame([x["Load"] for x in r["LoadInfo"]["FiveMinTotalLoad"]])
 
-        df["Time"] = df["Time"].apply(lambda x, date=date: date + pd.Timedelta(hours=int(
-            x.split(":")[0]), minutes=int(x.split(":")[1])))
+        df["Time"] = df["Time"].apply(
+            lambda x, date=date: date
+            + pd.Timedelta(hours=int(x.split(":")[0]), minutes=int(x.split(":")[1])),
+        )
         df["Time"] = df["Time"].dt.tz_localize(self.default_timezone)
         df = df.rename(columns={"Value": "Demand"})
 

--- a/isodata/miso.py
+++ b/isodata/miso.py
@@ -41,7 +41,7 @@ class MISO(ISOBase):
         r = self._get_json(url)
 
         return {
-            "time": pd.to_datetime(r[1]["d"]).tz_localize(self.default_timezone),
+            "time": pd.to_datetime(r[1]["d"]).tz_convert(self.default_timezone),
             "demand": float(r[1]["v"].replace(",", "")),
         }
 

--- a/isodata/miso.py
+++ b/isodata/miso.py
@@ -41,7 +41,7 @@ class MISO(ISOBase):
         r = self._get_json(url)
 
         return {
-            "time": pd.to_datetime(r[1]["d"]).tz_convert(self.default_timezone),
+            "time": pd.to_datetime(r[1]["d"]).tz_localize(self.default_timezone),
             "demand": float(r[1]["v"].replace(",", "")),
         }
 

--- a/isodata/nyiso.py
+++ b/isodata/nyiso.py
@@ -1,9 +1,11 @@
-import requests
-from .base import ISOBase, FuelMix
-import pandas as pd
-import isodata
 import io
 from zipfile import ZipFile
+
+import pandas as pd
+import requests
+
+import isodata
+from isodata.base import FuelMix, ISOBase
 
 
 class NYISO(ISOBase):
@@ -23,8 +25,9 @@ class NYISO(ISOBase):
         mix_df = pd.DataFrame(data["data"])
         time_str = mix_df["timeStamp"].max()
         time = pd.Timestamp(time_str)
-        mix_df = mix_df[mix_df["timeStamp"]
-                        == time_str].set_index("fuelCategory")["genMWh"]
+        mix_df = mix_df[mix_df["timeStamp"] == time_str].set_index("fuelCategory")[
+            "genMWh"
+        ]
         mix_dict = mix_df.to_dict()
         return FuelMix(time=time, mix=mix_dict, iso=self.name)
 
@@ -38,11 +41,16 @@ class NYISO(ISOBase):
 
     def get_historical_fuel_mix(self, date):
         mix_df = _download_nyiso_archive(date, "rtfuelmix")
-        mix_df = mix_df.pivot_table(index="Time Stamp",
-                                    columns="Fuel Category", values="Gen MW", aggfunc="first").reset_index()
+        mix_df = mix_df.pivot_table(
+            index="Time Stamp",
+            columns="Fuel Category",
+            values="Gen MW",
+            aggfunc="first",
+        ).reset_index()
 
-        mix_df["Time Stamp"] = pd.to_datetime(
-            mix_df["Time Stamp"]).dt.tz_localize(self.default_timezone)
+        mix_df["Time Stamp"] = pd.to_datetime(mix_df["Time Stamp"]).dt.tz_localize(
+            self.default_timezone,
+        )
 
         mix_df = mix_df.rename(columns={"Time Stamp": "Time"})
 
@@ -63,14 +71,13 @@ class NYISO(ISOBase):
         """Returns demand at a previous date in 5 minute intervals"""
         data = _download_nyiso_archive(date, "pal")
 
-        demand = data.groupby("Time Stamp")[
-            "Load"].sum().reset_index()
+        demand = data.groupby("Time Stamp")["Load"].sum().reset_index()
 
-        demand = demand.rename(columns={"Time Stamp": "Time",
-                                        "Load": "Demand"})
+        demand = demand.rename(columns={"Time Stamp": "Time", "Load": "Demand"})
 
-        demand["Time"] = pd.to_datetime(
-            demand["Time"]).dt.tz_localize(self.default_timezone)
+        demand["Time"] = pd.to_datetime(demand["Time"]).dt.tz_localize(
+            self.default_timezone,
+        )
 
         return demand
 
@@ -101,12 +108,12 @@ class NYISO(ISOBase):
 
 def _download_nyiso_archive(date, filename):
     date = isodata.utils._handle_date(date)
-    month = date.strftime('%Y%m01')
-    day = date.strftime('%Y%m%d')
+    month = date.strftime("%Y%m01")
+    day = date.strftime("%Y%m%d")
 
     file = f"{day}{filename}.csv"
-    csv_url = f'http://mis.nyiso.com/public/csv/{filename}/{file}'
-    zip_url = f'http://mis.nyiso.com/public/csv/{filename}/{month}{filename}_csv.zip'
+    csv_url = f"http://mis.nyiso.com/public/csv/{filename}/{file}"
+    zip_url = f"http://mis.nyiso.com/public/csv/{filename}/{month}{filename}_csv.zip"
 
     # the last 7 days of file are hosted directly as csv
     try:

--- a/isodata/pjm.py
+++ b/isodata/pjm.py
@@ -1,15 +1,17 @@
 import imp
-import requests
-from .base import ISOBase, FuelMix
-import pandas as pd
-import isodata
 import io
+
+import pandas as pd
+import requests
+
+import isodata
+from isodata.base import FuelMix, ISOBase
 
 
 class PJM(ISOBase):
     name = "PJM"
     iso_id = "pjm"
-    default_timezone = 'US/Eastern'
+    default_timezone = "US/Eastern"
 
     def get_latest_fuel_mix(self):
         mix = self.get_fuel_mix_today()
@@ -31,23 +33,33 @@ class PJM(ISOBase):
         tomorrow = date + pd.DateOffset(1)
 
         data = {
-            "datetime_beginning_ept": date.strftime('%m/%d/%Y 00:00') + "to" + tomorrow.strftime('%m/%d/%Y 00:00'),
+            "datetime_beginning_ept": date.strftime("%m/%d/%Y 00:00")
+            + "to"
+            + tomorrow.strftime("%m/%d/%Y 00:00"),
             "fields": "datetime_beginning_ept,fuel_type,is_renewable,mw",
             "rowCount": 1000,
-            "startRow": 1
+            "startRow": 1,
         }
 
         # todo consider converting this to csv like demand
         key = self._get_key()
-        r = self._get_json("https://api.pjm.com/api/v1/gen_by_fuel", params=data,
-                           headers={"Ocp-Apim-Subscription-Key": key})
+        r = self._get_json(
+            "https://api.pjm.com/api/v1/gen_by_fuel",
+            params=data,
+            headers={"Ocp-Apim-Subscription-Key": key},
+        )
         mix_df = pd.DataFrame(r["items"])
 
-        mix_df = mix_df.pivot_table(index="datetime_beginning_ept",
-                                    columns="fuel_type", values="mw", aggfunc="first").reset_index()
+        mix_df = mix_df.pivot_table(
+            index="datetime_beginning_ept",
+            columns="fuel_type",
+            values="mw",
+            aggfunc="first",
+        ).reset_index()
 
         mix_df["datetime_beginning_ept"] = pd.to_datetime(
-            mix_df["datetime_beginning_ept"]).dt.tz_localize(self.default_timezone)
+            mix_df["datetime_beginning_ept"],
+        ).dt.tz_localize(self.default_timezone)
 
         mix_df = mix_df.rename(columns={"datetime_beginning_ept": "Time"})
 
@@ -89,37 +101,45 @@ class PJM(ISOBase):
         tomorrow = date + pd.DateOffset(1)
 
         data = {
-            "datetime_beginning_ept": date.strftime('%m/%d/%Y 00:00') + "to" + tomorrow.strftime('%m/%d/%Y 00:00'),
-            'sort': 'datetime_beginning_utc',
-            'order': 'Asc',
-            'startRow': 1,
-            'isActiveMetadata': 'true',
-            'fields': 'area,datetime_beginning_ept,instantaneous_load',
-            'format': 'csv',
-            'download': 'true',
+            "datetime_beginning_ept": date.strftime("%m/%d/%Y 00:00")
+            + "to"
+            + tomorrow.strftime("%m/%d/%Y 00:00"),
+            "sort": "datetime_beginning_utc",
+            "order": "Asc",
+            "startRow": 1,
+            "isActiveMetadata": "true",
+            "fields": "area,datetime_beginning_ept,instantaneous_load",
+            "format": "csv",
+            "download": "true",
         }
         key = self._get_key()
-        r = requests.get('https://api.pjm.com/api/v1/inst_load', params=data,
-                         headers={
-                             "Ocp-Apim-Subscription-Key": key})
+        r = requests.get(
+            "https://api.pjm.com/api/v1/inst_load",
+            params=data,
+            headers={"Ocp-Apim-Subscription-Key": key},
+        )
 
         data = pd.read_csv(io.StringIO(r.content.decode("utf8")))
 
-        demand = data.groupby("datetime_beginning_ept")[
-            "instantaneous_load"].sum().reset_index()
+        demand = (
+            data.groupby("datetime_beginning_ept")["instantaneous_load"]
+            .sum()
+            .reset_index()
+        )
 
-        demand = demand.rename(columns={"datetime_beginning_ept": "Time",
-                                        "instantaneous_load": "Demand"})
+        demand = demand.rename(
+            columns={"datetime_beginning_ept": "Time", "instantaneous_load": "Demand"},
+        )
 
-        demand["Time"] = pd.to_datetime(
-            demand["Time"]).dt.tz_localize(self.default_timezone)
+        demand["Time"] = pd.to_datetime(demand["Time"]).dt.tz_localize(
+            self.default_timezone,
+        )
 
         demand = demand.sort_values("Time").reset_index(drop=True)
         return demand
 
     def _get_key(self):
-        settings = self._get_json(
-            "https://dataminer2.pjm.com/config/settings.json")
+        settings = self._get_json("https://dataminer2.pjm.com/config/settings.json")
 
         return settings["subscriptionKey"]
 

--- a/isodata/pjm.py
+++ b/isodata/pjm.py
@@ -1,4 +1,3 @@
-import imp
 import io
 
 import pandas as pd

--- a/isodata/spp.py
+++ b/isodata/spp.py
@@ -1,5 +1,6 @@
-from .base import ISOBase, FuelMix
 import pandas as pd
+
+from isodata.base import FuelMix, ISOBase
 
 
 class SPP(ISOBase):
@@ -10,9 +11,7 @@ class SPP(ISOBase):
         url = "https://marketplace.spp.org/chart-api/gen-mix/asChart"
         r = self._get_json(url)["response"]
 
-        data = {
-            "Timestamp":  r["labels"]
-        }
+        data = {"Timestamp": r["labels"]}
         data.update((d["label"], d["data"]) for d in r["datasets"])
 
         historical_mix = pd.DataFrame(data)
@@ -32,22 +31,23 @@ class SPP(ISOBase):
 
     def get_demand_today(self):
         """Returns demand for last 24hrs in 5 minute intervals"""
-        url = 'https://marketplace.spp.org/chart-api/load-forecast/asChart'
-        r = self._get_json(url)['response']
+        url = "https://marketplace.spp.org/chart-api/load-forecast/asChart"
+        r = self._get_json(url)["response"]
 
         load = r["datasets"][2]
 
         # sanity check to make sure direct index of 2 is correct
         assert load["label"] == "Actual Load"
 
-        df = pd.DataFrame({
-            "Time": r["labels"],
-            "Demand": load["data"]
-        }).dropna(subset=["Demand"])
+        df = pd.DataFrame({"Time": r["labels"], "Demand": load["data"]}).dropna(
+            subset=["Demand"],
+        )
 
         df["Time"] = pd.to_datetime(df["Time"])
 
         return df
+
+
 # historical generation mix
 # https://marketplace.spp.org/pages/generation-mix-rolling-365
 # https://marketplace.spp.org/chart-api/gen-mix-365/asFile

--- a/isodata/tests/test_isos.py
+++ b/isodata/tests/test_isos.py
@@ -1,15 +1,15 @@
-from isodata import *
-import isodata
-from isodata.base import FuelMix, ISOBase, GridStatus
 import pandas as pd
 import pytest
 from pandas.api.types import is_numeric_dtype
 
+import isodata
+from isodata import *
+from isodata.base import FuelMix, GridStatus, ISOBase
 
 all_isos = [MISO(), CAISO(), PJM(), Ercot(), SPP(), NYISO(), ISONE()]
 
 
-@pytest.mark.parametrize('iso', all_isos)
+@pytest.mark.parametrize("iso", all_isos)
 def test_get_latest_fuel_mix(iso):
     print(iso)
     mix = iso.get_latest_fuel_mix()
@@ -21,7 +21,7 @@ def test_get_latest_fuel_mix(iso):
     assert isinstance(repr(mix), str)
 
 
-@pytest.mark.parametrize('iso', [ISONE(), NYISO(), CAISO(), PJM()])
+@pytest.mark.parametrize("iso", [ISONE(), NYISO(), CAISO(), PJM()])
 def test_get_fuel_mix(iso):
     df = iso.get_fuel_mix_today()
     assert isinstance(df, pd.DataFrame)
@@ -44,54 +44,54 @@ def test_get_iso_invalid():
         isodata.get_iso("ISO DOESNT EXIST")
 
 
-@pytest.mark.parametrize('iso', [CAISO(), Ercot()])
+@pytest.mark.parametrize("iso", [CAISO(), Ercot()])
 def test_get_latest_status(iso):
     status = iso.get_latest_status()
     assert isinstance(status, GridStatus)
 
 
-@pytest.mark.parametrize('iso', [ISONE(), NYISO(), PJM(), CAISO()])
+@pytest.mark.parametrize("iso", [ISONE(), NYISO(), PJM(), CAISO()])
 def test_get_historical_fuel_mix(iso):
     # date string works
     date_str = "04/03/2022"
     df = iso.get_historical_fuel_mix(date_str)
     assert isinstance(df, pd.DataFrame)
-    assert df.loc[0]["Time"].strftime('%m/%d/%Y') == date_str
+    assert df.loc[0]["Time"].strftime("%m/%d/%Y") == date_str
     assert df.loc[0]["Time"].tz is not None
 
     # timestamp object works
     date_obj = pd.to_datetime("2019/11/19")
     df = iso.get_historical_fuel_mix(date_obj)
     assert isinstance(df, pd.DataFrame)
-    assert df.loc[0]["Time"].strftime('%Y%m%d') == date_obj.strftime('%Y%m%d')
+    assert df.loc[0]["Time"].strftime("%Y%m%d") == date_obj.strftime("%Y%m%d")
     assert df.loc[0]["Time"].tz is not None
 
     # datetime object works
     date_obj = pd.to_datetime("2021/05/09").date()
     df = iso.get_historical_fuel_mix(date_obj)
     assert isinstance(df, pd.DataFrame)
-    assert df.loc[0]["Time"].strftime('%Y%m%d') == date_obj.strftime('%Y%m%d')
+    assert df.loc[0]["Time"].strftime("%Y%m%d") == date_obj.strftime("%Y%m%d")
     assert df.loc[0]["Time"].tz is not None
 
 
-@pytest.mark.parametrize('iso', all_isos)
+@pytest.mark.parametrize("iso", all_isos)
 def test_get_latest_supply(iso):
     supply = iso.get_latest_supply()
     set(["time", "supply"]) == supply.keys()
     assert is_numeric_dtype(type(supply["supply"]))
 
 
-@pytest.mark.parametrize('iso', [ISONE(), Ercot(), NYISO(), PJM(), CAISO()])
+@pytest.mark.parametrize("iso", [ISONE(), Ercot(), NYISO(), PJM(), CAISO()])
 def test_get_supply_today(iso):
     # todo check that the date is right
     df = iso.get_supply_today()
     assert isinstance(df, pd.DataFrame)
     set(["Time", "Supply"]) == set(df.columns)
-    assert is_numeric_dtype(df['Supply'])
+    assert is_numeric_dtype(df["Supply"])
     assert df.loc[0]["Time"].tz is not None
 
 
-@pytest.mark.parametrize('iso', [ISONE(), NYISO(), PJM(), CAISO()])
+@pytest.mark.parametrize("iso", [ISONE(), NYISO(), PJM(), CAISO()])
 def test_get_supply(iso):
     df = iso.get_supply_yesterday()
     assert isinstance(df, pd.DataFrame)
@@ -100,63 +100,62 @@ def test_get_supply(iso):
     df = iso.get_historical_supply(date_str)
     assert isinstance(df, pd.DataFrame)
     assert set(["Time", "Supply"]) == set(df.columns)
-    assert df.loc[0]["Time"].date(
-    ) == isodata.utils._handle_date(date_str).date()
-    assert is_numeric_dtype(df['Supply'])
+    assert df.loc[0]["Time"].date() == isodata.utils._handle_date(date_str).date()
+    assert is_numeric_dtype(df["Supply"])
     assert df.loc[0]["Time"].tz is not None
 
 
-@pytest.mark.parametrize('iso', all_isos)
+@pytest.mark.parametrize("iso", all_isos)
 def test_get_demand_today(iso):
     df = iso.get_demand_today()
     assert isinstance(df, pd.DataFrame)
     assert set(["Time", "Demand"]) == set(df.columns)
-    assert is_numeric_dtype(df['Demand'])
+    assert is_numeric_dtype(df["Demand"])
     assert isinstance(df.loc[0]["Time"], pd.Timestamp)
     assert df.loc[0]["Time"].tz is not None
 
 
-@pytest.mark.parametrize('iso', [PJM(), NYISO(), Ercot(), ISONE(), CAISO()])
+@pytest.mark.parametrize("iso", [PJM(), NYISO(), Ercot(), ISONE(), CAISO()])
 def test_get_demand_yesterday(iso):
     # todo check that the date is right
     df = iso.get_demand_yesterday()
     assert isinstance(df, pd.DataFrame)
     assert set(["Time", "Demand"]) == set(df.columns)
-    assert is_numeric_dtype(df['Demand'])
+    assert is_numeric_dtype(df["Demand"])
     assert isinstance(df.loc[0]["Time"], pd.Timestamp)
     assert df.loc[0]["Time"].tz is not None
 
 
-@pytest.mark.parametrize('iso', all_isos)
+@pytest.mark.parametrize("iso", all_isos)
 def test_get_latest_demand(iso):
     demand = iso.get_latest_demand()
     set(["time", "demand"]) == demand.keys()
     assert is_numeric_dtype(type(demand["demand"]))
 
 
-@pytest.mark.parametrize('iso', [PJM(), NYISO(), ISONE(), CAISO()])
+@pytest.mark.parametrize("iso", [PJM(), NYISO(), ISONE(), CAISO()])
 def test_get_historical_demand(iso):
     # pick a test date 2 weeks back
     test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
 
     # date string works
-    date_str = test_date.strftime('%Y%m%d')
+    date_str = test_date.strftime("%Y%m%d")
     df = iso.get_historical_demand(date_str)
     assert isinstance(df, pd.DataFrame)
     assert set(["Time", "Demand"]) == set(df.columns)
-    assert df.loc[0]["Time"].strftime('%Y%m%d') == date_str
-    assert is_numeric_dtype(df['Demand'])
+    assert df.loc[0]["Time"].strftime("%Y%m%d") == date_str
+    assert is_numeric_dtype(df["Demand"])
 
     # timestamp object works
     df = iso.get_historical_demand(test_date)
     assert isinstance(df, pd.DataFrame)
     assert set(["Time", "Demand"]) == set(df.columns)
-    assert df.loc[0]["Time"].strftime('%Y%m%d') == test_date.strftime('%Y%m%d')
-    assert is_numeric_dtype(df['Demand'])
+    assert df.loc[0]["Time"].strftime("%Y%m%d") == test_date.strftime("%Y%m%d")
+    assert is_numeric_dtype(df["Demand"])
 
     # datetime object works
     df = iso.get_historical_demand(test_date)
     assert isinstance(df, pd.DataFrame)
     assert set(["Time", "Demand"]) == set(df.columns)
-    assert df.loc[0]["Time"].strftime('%Y%m%d') == test_date.strftime('%Y%m%d')
-    assert is_numeric_dtype(df['Demand'])
+    assert df.loc[0]["Time"].strftime("%Y%m%d") == test_date.strftime("%Y%m%d")
+    assert is_numeric_dtype(df["Demand"])

--- a/isodata/utils.py
+++ b/isodata/utils.py
@@ -1,13 +1,14 @@
+import pandas as pd
+
 import isodata
 from isodata.base import ISOBase
-import pandas as pd
-from isodata.nyiso import NYISO
 from isodata.caiso import CAISO
 from isodata.ercot import Ercot
 from isodata.isone import ISONE
 from isodata.miso import MISO
-from isodata.spp import SPP
+from isodata.nyiso import NYISO
 from isodata.pjm import PJM
+from isodata.spp import SPP
 
 all_isos = [MISO, CAISO, PJM, Ercot, SPP, NYISO, ISONE]
 
@@ -29,28 +30,28 @@ def get_iso(iso_id):
 
 def make_availability_df():
     methods = [
-        'get_latest_status',
-        'get_latest_fuel_mix',
-        'get_fuel_mix_today',
-        'get_fuel_mix_yesterday',
-        'get_historical_fuel_mix',
-        'get_latest_demand',
-        'get_demand_today',
-        'get_demand_yesterday',
-        'get_historical_demand',
-        'get_latest_supply',
-        'get_supply_today',
-        'get_supply_yesterday',
-        'get_historical_supply'
+        "get_latest_status",
+        "get_latest_fuel_mix",
+        "get_fuel_mix_today",
+        "get_fuel_mix_yesterday",
+        "get_historical_fuel_mix",
+        "get_latest_demand",
+        "get_demand_today",
+        "get_demand_yesterday",
+        "get_historical_demand",
+        "get_latest_supply",
+        "get_supply_today",
+        "get_supply_yesterday",
+        "get_historical_supply",
     ]
 
     availability = {}
     for i in isodata.all_isos:
         availability[i.name] = {}
         for m in methods:
-            is_defined = '&#10060;'  # red x
+            is_defined = "&#10060;"  # red x
             if getattr(i, m) != getattr(ISOBase, m):
-                is_defined = '&#x2705;'  # green checkmark
+                is_defined = "&#x2705;"  # green checkmark
             availability[i.name][m] = is_defined
 
     availability_df = pd.DataFrame(availability)
@@ -60,7 +61,7 @@ def make_availability_df():
 
 def make_availability_table():
     df = make_availability_df()
-    df.index = ["`"+v+"`" for v in df.index.values]
+    df.index = ["`" + v + "`" for v in df.index.values]
     return df.to_markdown()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,20 @@
 requires = [
     "setuptools >= 47",
     "wheel",
-    "requests >= 2.28.1",
-    "pandas >= 1.3.0",
-    "beautifulsoup4 >= 4.8.13",
-    "json5 >= 0.9.8",
-    "tabulate >= 0.8.10"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+testpaths = [
+    "isodata/tests/*"
+]
+
+[tool.isort]
+profile = "black"
+forced_separate = "isodata"
+known_first_party = "isodata"
+skip = "__init__.py"
+multi_line_output = 3
+
+[tool.black]
+target-version = ['py310']

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,9 +36,11 @@ python_requires = >=3.7, <4
 
 [options.extras_require]
 dev =
+    flake8 == 5.0.4
     isort == 5.10.1
     black == 22.6.0
     pre-commit == 2.20.0
+test =
     pytest == 7.1.2
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ dev =
     isort == 5.10.1
     black == 22.6.0
     pre-commit == 2.20.0
+    pytest == 7.1.2
 
 [options.package_data]
 * =

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ python_requires = >=3.7, <4
 dev =
     isort == 5.10.1
     black == 22.6.0
+    pre-commit == 2.20.0
 
 [options.package_data]
 * =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = isodata
-version = attr: isodata.__version__
+version = attr: isodata.version.__version__
 description = API to access energy data
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -9,14 +9,18 @@ author_email = kmax12@gmail.com
 license = BSD 3-clause
 license_files =
     LICENSE
-classifiers = 
+classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 keywords = energy, independent system operator
 
 [project.urls]
-Homepage = https://github.com/kmax12/isodata
-
+Source Code = https://github.com/kmax12/isodata
+Issue Tracker = https://github.com/kmax12/isodata/issues
 
 [options]
 zip_safe = False
@@ -30,6 +34,10 @@ install_requires =
     tabulate >= 0.8.10
 python_requires = >=3.7, <4
 
+[options.extras_require]
+dev =
+    isort == 5.10.1
+    black == 22.6.0
 
 [options.package_data]
 * =

--- a/update_readme.py
+++ b/update_readme.py
@@ -1,14 +1,19 @@
 import isodata
 
-start_str = '<!-- METHOD AVAILABILITY TABLE START -->'
-end_str = '<!-- METHOD AVAILABILITY TABLE END -->'
+start_str = "<!-- METHOD AVAILABILITY TABLE START -->"
+end_str = "<!-- METHOD AVAILABILITY TABLE END -->"
 
-with open('README.md', 'r+') as f:
+with open("README.md", "r+") as f:
     content = f.read()
     start = content.index(start_str) + len(start_str)
     end = content.index(end_str)
-    new_content = content[:start] + "\n" + \
-        isodata.make_availability_table() + "\n" + content[end:]
+    new_content = (
+        content[:start]
+        + "\n"
+        + isodata.make_availability_table()
+        + "\n"
+        + content[end:]
+    )
 
     f.seek(0)
     f.write(new_content)


### PR DESCRIPTION
- Added commands to Makefile to **handle** linting, and creating the .tar.gz + .whl file (for PyPI).
- Added [pre-commit](https://pre-commit.com/) so that you don't have to run `make lint-fix` before committing.
  - Added a few hooks.
  - These are set and forget. It will run when you do `git commit -m "commit msg"`.
- Due to pre-commit running on all files you now have the following benefit: 
  - Absolute imports everywhere.
  - Double quotes everywhere.
  - Trailing commas everywhere.
- `black` linting had been added ("uncompromising Python code formatter").
- `isort` has been added for sorted imports.
- `pyproject.toml` should not contain package requirements in `requires`. These have been removed.
- `version` in `setup.cfg` should specify the absolute path (to avoid importing unneeded module (the reason you had the previous error)).
- Added `.[dev]` extra requires. This contains the linting dependencies.
- Added lint check workflow to GitHub Actions CI.