### PR TITLE
Add status homepage url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - Add notes to Ercot status
+- Add `.status_homepage` url to ISOs that report a status
 
 ## v0.7.0 - Aug 23, 2022
 

--- a/isodata/base.py
+++ b/isodata/base.py
@@ -113,10 +113,13 @@ class GridStatus:
         self.notes = notes
 
     def __repr__(self) -> str:
-        s = self.iso + "\n"
+        s = self.iso.name + "\n"
 
         s += "Time: %s \n" % str(self.time)
         s += "Status: %s \n" % self.status
+
+        if self.iso.status_homepage:
+            s += "Status Homepage: %s \n" % self.iso.status_homepage
 
         if self.reserves is not None:
             s += "Reserves: %.0f %s" % (self.reserves, self.unit)

--- a/isodata/caiso.py
+++ b/isodata/caiso.py
@@ -20,6 +20,8 @@ class CAISO(ISOBase):
     iso_id = "caiso"
     default_timezone = "US/Pacific"
 
+    status_homepage = "https://www.caiso.com/TodaysOutlook/Pages/default.aspx"
+
     # Markets PRC_RTPD_LMP, PRC_HASP_LMP, PRC_LMP
     markets = [
         Markets.REAL_TIME_15_MIN,
@@ -45,7 +47,7 @@ class CAISO(ISOBase):
     def get_latest_status(self) -> str:
         """Get Current Status of the Grid
 
-        Known possible values: Normal
+        Known possible values: Normal, Restricted Maintenance Operations
         """
 
         # todo is it possible for this to return more than one element?
@@ -55,7 +57,7 @@ class CAISO(ISOBase):
         status = r["gridstatus"][0]
         reserves = r["Current_reserve"]
 
-        return GridStatus(time=time, status=status, reserves=reserves, iso=self.name)
+        return GridStatus(time=time, status=status, reserves=reserves, iso=self)
 
     def get_latest_fuel_mix(self):
         """

--- a/isodata/ercot.py
+++ b/isodata/ercot.py
@@ -11,6 +11,8 @@ class Ercot(ISOBase):
     iso_id = "ercot"
     default_timezone = "US/Central"
 
+    status_homepage = "https://www.ercot.com/gridmktinfo/dashboards/gridconditions"
+
     BASE = "https://www.ercot.com/api/1/services/read/dashboards"
 
     def get_latest_status(self):
@@ -33,7 +35,7 @@ class Ercot(ISOBase):
             time=time,
             status=status,
             reserves=reserves,
-            iso=self.name,
+            iso=self,
             notes=notes,
         )
 

--- a/isodata/isone.py
+++ b/isodata/isone.py
@@ -16,6 +16,8 @@ class ISONE(ISOBase):
     iso_id = "isone"
     default_timezone = "US/Eastern"
 
+    status_homepage = "https://www.iso-ne.com/markets-operations/system-forecast-status/current-system-status"
+
     markets = [
         Markets.REAL_TIME_5_MIN,
         Markets.REAL_TIME_HOURLY,
@@ -44,6 +46,9 @@ class ISONE(ISOBase):
 
     def get_latest_status(self):
         """Get latest status for ISO NE"""
+
+        # historical data available
+        # https://www.iso-ne.com/markets-operations/system-forecast-status/current-system-status/power-system-status-list
         r = requests.post(
             "https://www.iso-ne.com/ws/wsclient",
             data={
@@ -62,7 +67,7 @@ class ISONE(ISOBase):
             time=time,
             status=status,
             reserves=None,
-            iso=self.name,
+            iso=self,
             notes=[note],
         )
 

--- a/isodata/nyiso.py
+++ b/isodata/nyiso.py
@@ -14,6 +14,7 @@ class NYISO(ISOBase):
     iso_id = "nyiso"
     default_timezone = "US/Eastern"
     markets = [Markets.REAL_TIME_5_MIN, Markets.DAY_AHEAD_5_MIN]
+    status_homepage = "https://www.nyiso.com/system-conditions"
 
     def get_latest_status(self):
         latest = self._latest_from_today(self.get_status_today)
@@ -22,7 +23,7 @@ class NYISO(ISOBase):
             time=latest["time"],
             status=latest["status"],
             reserves=None,
-            iso=self.name,
+            iso=self,
             notes=latest["notes"],
         )
         return status

--- a/isodata/spp.py
+++ b/isodata/spp.py
@@ -13,6 +13,8 @@ class SPP(ISOBase):
 
     default_timezone = "US/Central"
 
+    status_homepage = "https://www.spp.org/markets-operations/current-grid-conditions/"
+
     def get_latest_status(self):
         url = "https://www.spp.org/markets-operations/current-grid-conditions/"
         html_text = requests.get(url).text
@@ -67,7 +69,7 @@ class SPP(ISOBase):
             status=status,
             notes=notes,
             reserves=None,
-            iso=self.name,
+            iso=self,
         )
 
     def get_latest_fuel_mix(self):

--- a/isodata/tests/test_isos.py
+++ b/isodata/tests/test_isos.py
@@ -79,6 +79,9 @@ def test_get_latest_status(iso):
     status = iso.get_latest_status()
     assert isinstance(status, GridStatus)
 
+    # ensure there is a homepage if isodata can retrieve a status
+    assert isinstance(iso.status_homepage, str)
+
 
 @pytest.mark.parametrize("iso", [NYISO()])
 def test_get_historical_status(iso):


### PR DESCRIPTION
All ISOs that report a status now have a homepage url. This is important so people can get additional information in case of non-normal status

```
>>> import isodata
>>> iso = isodata.CAISO()
>>> iso.get_latest_status()
```
```
California ISO
Time: 2022-08-31 13:05:00-07:00 
Status: Restricted Maintenance Operations 
Status Homepage: https://www.caiso.com/TodaysOutlook/Pages/default.aspx 
Reserves: 3560 MW
```

you can access the url directly like this

```
>>> iso.status_homepage
```
```
'https://www.caiso.com/TodaysOutlook/Pages/default.aspx'
```