### PR TITLE
Add Ercot Historical RTM Settlement Point Prices (SPPs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.ipynb
 unpacked/*
 
+*.csv
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add notes to Ercot status
 - Add `.status_homepage` url to ISOs that report a status
-- Add historical RTM Settlement Prices to Ercot
+- Add Ercot Historical RTM Settlement Point Prices (SPPs)
 
 ## v0.7.0 - Aug 23, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add notes to Ercot status
 - Add `.status_homepage` url to ISOs that report a status
+- Add historical RTM Settlement Prices to Ercot
 
 ## v0.7.0 - Aug 23, 2022
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <a href="#getting-started"><b>Getting Started</b></a> — 
 <a href="#method-availability"><b>Method Availability</b></a> —  
 <a href="#lmp-pricing-data"><b>LMP Data</b></a> —  
-<a href="#supported-lmp-markets"><b>Supported LMP Markets</b></a> —  
+<a href="#supported-lmp-markets"><b>Supported LMP Markets</b></a> 
 </p>
 
 `isodata` provides a uniform API to access energy data from the major Independent System Operators (ISOs) in the United States.
@@ -203,22 +203,24 @@ The best part is these APIs work across all the supported ISOs
 Here is the current status of availability of each method for each ISO
 
 <!-- METHOD AVAILABILITY TABLE START -->
-|                           | New York ISO   | California ISO   | Electric Reliability Council of Texas   | ISO New England   | Midcontinent ISO   | Southwest Power Pool   | PJM      |
-|:--------------------------|:---------------|:-----------------|:----------------------------------------|:------------------|:-------------------|:-----------------------|:---------|
-| `get_latest_status`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#x2705;               | &#10060; |
-| `get_latest_fuel_mix`     | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_latest_demand`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_latest_supply`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_fuel_mix_today`      | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_demand_today`        | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_forecast_today`      | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
-| `get_supply_today`        | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_battery_today`       | &#10060;       | &#x2705;         | &#10060;                                | &#10060;          | &#10060;           | &#10060;               | &#10060; |
-| `get_historical_fuel_mix` | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_historical_demand`   | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_historical_forecast` | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#10060; |
-| `get_historical_supply`   | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
-| `get_historical_battery`  | &#10060;       | &#x2705;         | &#10060;                                | &#10060;          | &#10060;           | &#10060;               | &#10060; |
+
+|                           | New York ISO | California ISO | Electric Reliability Council of Texas | ISO New England | Midcontinent ISO | Southwest Power Pool | PJM      |
+| :------------------------ | :----------- | :------------- | :------------------------------------ | :-------------- | :--------------- | :------------------- | :------- |
+| `get_latest_status`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#x2705;             | &#10060; |
+| `get_latest_fuel_mix`     | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_latest_demand`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_latest_supply`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_fuel_mix_today`      | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_demand_today`        | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_forecast_today`      | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
+| `get_supply_today`        | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_battery_today`       | &#10060;     | &#x2705;       | &#10060;                              | &#10060;        | &#10060;         | &#10060;             | &#10060; |
+| `get_historical_fuel_mix` | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_historical_demand`   | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_historical_forecast` | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#10060; |
+| `get_historical_supply`   | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
+| `get_historical_battery`  | &#10060;     | &#x2705;       | &#10060;                              | &#10060;        | &#10060;         | &#10060;             | &#10060; |
+
 <!-- METHOD AVAILABILITY TABLE END -->
 
 ## LMP Pricing Data
@@ -288,8 +290,9 @@ The possible lmp query methods are `ISO.get_latest_lmp`, `ISO.get_lmp_today`, an
 ## Supported LMP Markets
 
 <!-- LMP AVAILABILITY TABLE START -->
+
 |                                       | Markets                                                    |
-|:--------------------------------------|:-----------------------------------------------------------|
+| :------------------------------------ | :--------------------------------------------------------- |
 | Midcontinent ISO                      | `REAL_TIME_5_MIN`, `DAY_AHEAD_HOURLY`                      |
 | California ISO                        | `REAL_TIME_15_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY` |
 | PJM                                   |                                                            |
@@ -297,6 +300,7 @@ The possible lmp query methods are `ISO.get_latest_lmp`, `ISO.get_lmp_today`, an
 | Southwest Power Pool                  |                                                            |
 | New York ISO                          | `REAL_TIME_5_MIN`, `DAY_AHEAD_5_MIN`                       |
 | ISO New England                       | `REAL_TIME_5_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY`  |
+
 <!-- LMP AVAILABILITY TABLE END -->
 
 ## Related projects

--- a/isodata/ercot.py
+++ b/isodata/ercot.py
@@ -147,7 +147,7 @@ class Ercot(ISOBase):
         return doc
 
     def get_historical_rtm_spp(self, year):
-        """Get historical rtm settlement prices by year
+        """Get Historical RTM Settlement Point Prices (SPPs) for each of the Hubs and Load Zones
 
         Arguments:
             year (int): year to get data for

--- a/isodata/ercot.py
+++ b/isodata/ercot.py
@@ -1,9 +1,4 @@
-import io
-from bdb import set_trace
-from zipfile import ZipFile
-
 import pandas as pd
-import requests
 
 from isodata import utils
 from isodata.base import FuelMix, GridStatus, ISOBase
@@ -154,6 +149,9 @@ class Ercot(ISOBase):
     def get_historical_rtm_spp(self, year):
         """Get historical rtm settlement prices by year
 
+        Arguments:
+            year (int): year to get data for
+
         Source: https://www.ercot.com/mp/data-products/data-product-details?id=NP6-785-ER
         """
         doc_url, date = self._get_document(
@@ -161,7 +159,8 @@ class Ercot(ISOBase):
             constructed_name_contains=f"{year}.zip",
             verbose=True,
         )
-        x = get_zip_file(doc_url)
+
+        x = utils.get_zip_file(doc_url)
         all_sheets = pd.read_excel(x, sheet_name=None)
         df = pd.concat(all_sheets.values())
         return df
@@ -214,13 +213,6 @@ class Ercot(ISOBase):
         return df[cols_to_keep].rename(columns=columns)
 
 
-def get_zip_file(url):
-    # todo add retry logic
-    # todo does this need to be a with statement?
-    r = requests.get(url)
-    z = ZipFile(io.BytesIO(r.content))
-    return z.open(z.namelist()[0])
-
-
 if __name__ == "__main__":
     iso = Ercot()
+    iso.get_historical_rtm_spp(2020)

--- a/isodata/miso.py
+++ b/isodata/miso.py
@@ -171,7 +171,6 @@ class MISO(ISOBase):
             ]
         ]
 
-        # todo add a test for filtering locations
         data = utils.filter_lmp_locations(data, locations)
 
         return data

--- a/isodata/miso.py
+++ b/isodata/miso.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from pandas import Timestamp
 
+from isodata import utils
 from isodata.base import FuelMix, ISOBase, Markets
 
 
@@ -169,6 +170,9 @@ class MISO(ISOBase):
                 "Loss",
             ]
         ]
+
+        # todo add a test for filtering locations
+        data = utils.filter_lmp_locations(data, locations)
 
         return data
 

--- a/isodata/tests/test_isos.py
+++ b/isodata/tests/test_isos.py
@@ -340,3 +340,9 @@ def test_ercot_get_historical_rtm_spp():
     rtm = Ercot().get_historical_rtm_spp(2020)
     assert isinstance(rtm, pd.DataFrame)
     assert len(rtm) > 0
+
+
+def test_miso_locations():
+    iso = MISO()
+    data = iso.get_latest_lmp(Markets.REAL_TIME_5_MIN, locations=iso.hubs)
+    assert set(data["Location"].unique()) == set(iso.hubs)

--- a/isodata/tests/test_isos.py
+++ b/isodata/tests/test_isos.py
@@ -333,3 +333,10 @@ def test_get_historical_battery(iso):
     test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
     battery = iso.get_historical_battery(test_date)
     check_battery(battery)
+
+
+@pytest.mark.skip(reason="takes too long to run")
+def test_ercot_get_historical_rtm_spp():
+    rtm = Ercot().get_historical_rtm_spp(2020)
+    assert isinstance(rtm, pd.DataFrame)
+    assert len(rtm) > 0

--- a/isodata/utils.py
+++ b/isodata/utils.py
@@ -1,6 +1,8 @@
-from datetime import datetime
+import io
+from zipfile import ZipFile
 
 import pandas as pd
+import requests
 
 import isodata
 from isodata.base import ISOBase, Markets
@@ -101,3 +103,11 @@ def filter_lmp_locations(data, locations: list):
         return data
 
     return data[data["Location"].isin(locations)]
+
+
+def get_zip_file(url):
+    # todo add retry logic
+    # todo does this need to be a with statement?
+    r = requests.get(url)
+    z = ZipFile(io.BytesIO(r.content))
+    return z.open(z.namelist()[0])


### PR DESCRIPTION
Historical RTM Settlement Point Prices (SPPs) for each of the Hubs and Load Zones.

```
>>> import isodata
>>> iso = isodata.Ercot()
>>> iso.get_historical_rtm_spp(year=2020)
```

```
      Delivery Date  Delivery Hour  ...  Settlement Point Type Settlement Point Price
0        01/01/2020            1.0  ...                     SH                  12.46
1        01/01/2020            1.0  ...                     SH                  14.22
2        01/01/2020            1.0  ...                     SH                  14.06
3        01/01/2020            1.0  ...                     SH                  14.09
4        01/01/2020            1.0  ...                     HU                  12.46
...             ...            ...  ...                    ...                    ...
68443    12/31/2020           24.0  ...                   LZEW                  15.92
68444    12/31/2020           24.0  ...                     LZ                  15.59
68445    12/31/2020           24.0  ...                   LZEW                  15.59
68446    12/31/2020           24.0  ...                     LZ                  15.91
68447    12/31/2020           24.0  ...                   LZEW                  15.91

[808129 rows x 7 columns]
```