### PR TITLE
Refactor Storage API to support non-battery storage types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add notes to Ercot status
 - Add `.status_homepage` url to ISOs that report a status
 - Add Ercot Historical RTM Settlement Point Prices (SPPs)
+- Refactor storage API to support not battery storage types
 
 ## v0.7.0 - Aug 23, 2022
 

--- a/README.md
+++ b/README.md
@@ -203,24 +203,22 @@ The best part is these APIs work across all the supported ISOs
 Here is the current status of availability of each method for each ISO
 
 <!-- METHOD AVAILABILITY TABLE START -->
-
-|                           | New York ISO | California ISO | Electric Reliability Council of Texas | ISO New England | Midcontinent ISO | Southwest Power Pool | PJM      |
-| :------------------------ | :----------- | :------------- | :------------------------------------ | :-------------- | :--------------- | :------------------- | :------- |
-| `get_latest_status`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#x2705;             | &#10060; |
-| `get_latest_fuel_mix`     | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
-| `get_latest_demand`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
-| `get_latest_supply`       | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
-| `get_fuel_mix_today`      | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_demand_today`        | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
-| `get_forecast_today`      | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#x2705;         | &#x2705;             | &#x2705; |
-| `get_supply_today`        | &#x2705;     | &#x2705;       | &#x2705;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_battery_today`       | &#10060;     | &#x2705;       | &#10060;                              | &#10060;        | &#10060;         | &#10060;             | &#10060; |
-| `get_historical_fuel_mix` | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_historical_demand`   | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_historical_forecast` | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#10060; |
-| `get_historical_supply`   | &#x2705;     | &#x2705;       | &#10060;                              | &#x2705;        | &#10060;         | &#10060;             | &#x2705; |
-| `get_historical_battery`  | &#10060;     | &#x2705;       | &#10060;                              | &#10060;        | &#10060;         | &#10060;             | &#10060; |
-
+|                           | New York ISO   | California ISO   | Electric Reliability Council of Texas   | ISO New England   | Midcontinent ISO   | Southwest Power Pool   | PJM      |
+|:--------------------------|:---------------|:-----------------|:----------------------------------------|:------------------|:-------------------|:-----------------------|:---------|
+| `get_latest_status`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#x2705;               | &#10060; |
+| `get_latest_fuel_mix`     | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
+| `get_latest_demand`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
+| `get_latest_supply`       | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
+| `get_fuel_mix_today`      | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_demand_today`        | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
+| `get_forecast_today`      | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#x2705;           | &#x2705;               | &#x2705; |
+| `get_supply_today`        | &#x2705;       | &#x2705;         | &#x2705;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_storage_today`       | &#10060;       | &#x2705;         | &#10060;                                | &#10060;          | &#10060;           | &#10060;               | &#10060; |
+| `get_historical_fuel_mix` | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_historical_demand`   | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_historical_forecast` | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#10060; |
+| `get_historical_supply`   | &#x2705;       | &#x2705;         | &#10060;                                | &#x2705;          | &#10060;           | &#10060;               | &#x2705; |
+| `get_historical_storage`  | &#10060;       | &#x2705;         | &#10060;                                | &#10060;          | &#10060;           | &#10060;               | &#10060; |
 <!-- METHOD AVAILABILITY TABLE END -->
 
 ## LMP Pricing Data
@@ -290,9 +288,8 @@ The possible lmp query methods are `ISO.get_latest_lmp`, `ISO.get_lmp_today`, an
 ## Supported LMP Markets
 
 <!-- LMP AVAILABILITY TABLE START -->
-
 |                                       | Markets                                                    |
-| :------------------------------------ | :--------------------------------------------------------- |
+|:--------------------------------------|:-----------------------------------------------------------|
 | Midcontinent ISO                      | `REAL_TIME_5_MIN`, `DAY_AHEAD_HOURLY`                      |
 | California ISO                        | `REAL_TIME_15_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY` |
 | PJM                                   |                                                            |
@@ -300,7 +297,6 @@ The possible lmp query methods are `ISO.get_latest_lmp`, `ISO.get_lmp_today`, an
 | Southwest Power Pool                  |                                                            |
 | New York ISO                          | `REAL_TIME_5_MIN`, `DAY_AHEAD_5_MIN`                       |
 | ISO New England                       | `REAL_TIME_5_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY`  |
-
 <!-- LMP AVAILABILITY TABLE END -->
 
 ## Related projects

--- a/isodata/base.py
+++ b/isodata/base.py
@@ -68,10 +68,10 @@ class ISOBase:
     def get_historical_supply(self, date):
         raise NotImplementedError()
 
-    def get_battery_today(self):
+    def get_storage_today(self):
         raise NotImplementedError()
 
-    def get_historical_battery(self, date):
+    def get_historical_storage(self, date):
         raise NotImplementedError()
 
     def _latest_lmp_from_today(self, market, locations):

--- a/isodata/caiso.py
+++ b/isodata/caiso.py
@@ -319,18 +319,18 @@ class CAISO(ISOBase):
 
         return df
 
-    def get_battery_today(self):
-        """Return battery charging or discharging for today in 5 minute intervals
+    def get_storage_today(self):
+        """Return storage charging or discharging for today in 5 minute intervals
 
         Negative means charging, positive means discharging
 
         Arguments:
             date: date to return data
         """
-        return self._today_from_historical(self.get_historical_battery)
+        return self._today_from_historical(self.get_historical_storage)
 
-    def get_historical_battery(self, date):
-        """Return battery charging or discharging at a previous date in 5 minute intervals
+    def get_historical_storage(self, date):
+        """Return storage charging or discharging at a previous date in 5 minute intervals
 
         Negative means charging, positive means discharging
 
@@ -340,7 +340,9 @@ class CAISO(ISOBase):
         date = isodata.utils._handle_date(date)
         url = self.HISTORY_BASE + "/%s/storage.csv"
         df = _get_historical(url, date)
-        df = df.rename(columns={"Batteries": "Battery Supply"})
+
+        df = df.rename(columns={"Batteries": "Supply"})
+        df["Type"] = "Batteries"
         return df
 
 

--- a/isodata/tests/test_isos.py
+++ b/isodata/tests/test_isos.py
@@ -32,9 +32,9 @@ def check_forecast(df):
     )
 
 
-def check_battery(df):
+def check_storage(df):
     assert set(df.columns) == set(
-        ["Time", "Battery Supply"],
+        ["Time", "Supply", "Type"],
     )
 
 
@@ -320,19 +320,19 @@ def test_get_forecast_today(iso):
     "iso",
     [CAISO()],
 )
-def test_get_battery_today(iso):
-    battery = iso.get_battery_today()
-    check_battery(battery)
+def test_get_storage_today(iso):
+    storage = iso.get_storage_today()
+    check_storage(storage)
 
 
 @pytest.mark.parametrize(
     "iso",
     [CAISO()],
 )
-def test_get_historical_battery(iso):
+def test_get_historical_storage(iso):
     test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
-    battery = iso.get_historical_battery(test_date)
-    check_battery(battery)
+    storage = iso.get_historical_storage(test_date)
+    check_storage(storage)
 
 
 @pytest.mark.skip(reason="takes too long to run")

--- a/isodata/utils.py
+++ b/isodata/utils.py
@@ -42,12 +42,12 @@ def make_availability_df():
         "get_demand_today",
         "get_forecast_today",
         "get_supply_today",
-        "get_battery_today",
+        "get_storage_today",
         "get_historical_fuel_mix",
         "get_historical_demand",
         "get_historical_forecast",
         "get_historical_supply",
-        "get_historical_battery",
+        "get_historical_storage",
     ]
 
     availability = {}


### PR DESCRIPTION
New api

```python
>>> import isodata
>>> caiso = isodata.CAISO()
>>> caiso.get_storage_today()
                         Time  Supply       Type
0   2022-09-20 00:00:00-07:00     -78  Batteries
1   2022-09-20 00:05:00-07:00     113  Batteries
2   2022-09-20 00:10:00-07:00      90  Batteries
3   2022-09-20 00:15:00-07:00      71  Batteries
4   2022-09-20 00:20:00-07:00     113  Batteries
..                        ...     ...        ...
107 2022-09-20 08:55:00-07:00    -653  Batteries
108 2022-09-20 09:00:00-07:00    -771  Batteries
109 2022-09-20 09:05:00-07:00    -718  Batteries
110 2022-09-20 09:10:00-07:00    -802  Batteries
111 2022-09-20 09:15:00-07:00    -969  Batteries

[112 rows x 3 columns]
````