### PR TITLE
Add LMPs for PJM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vNext
 
+- PJM: add lmp prices for 3 markets: real time 5 minutes, real time hourly, day ahead hourly
 - Add notes to Ercot status
 - Add `.status_homepage` url to ISOs that report a status
 - Add Ercot Historical RTM Settlement Point Prices (SPPs)

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ The possible lmp query methods are `ISO.get_latest_lmp`, `ISO.get_lmp_today`, an
 |:--------------------------------------|:-----------------------------------------------------------|
 | Midcontinent ISO                      | `REAL_TIME_5_MIN`, `DAY_AHEAD_HOURLY`                      |
 | California ISO                        | `REAL_TIME_15_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY` |
-| PJM                                   |                                                            |
+| PJM                                   | `REAL_TIME_5_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY`  |
 | Electric Reliability Council of Texas |                                                            |
 | Southwest Power Pool                  |                                                            |
 | New York ISO                          | `REAL_TIME_5_MIN`, `DAY_AHEAD_5_MIN`                       |

--- a/isodata/nyiso.py
+++ b/isodata/nyiso.py
@@ -151,7 +151,7 @@ class NYISO(ISOBase):
         return self._latest_lmp_from_today(market, locations)
 
     def get_lmp_today(self, market: str, locations: list = None):
-        "Get lmp for today in 5 minute intervals"
+        "Get lmp for today"
         return self._today_from_historical(self.get_historical_lmp, market, locations)
 
     def get_historical_lmp(self, date, market: str, locations: list = None):

--- a/isodata/nyiso.py
+++ b/isodata/nyiso.py
@@ -204,7 +204,7 @@ class NYISO(ISOBase):
             ]
         ]
 
-        data = utils.filter_lmp_locations(df, locations)
+        df = utils.filter_lmp_locations(df, locations)
 
         return df
 

--- a/isodata/tests/test_isos.py
+++ b/isodata/tests/test_isos.py
@@ -9,8 +9,8 @@ from isodata.base import FuelMix, GridStatus, ISOBase
 all_isos = [MISO(), CAISO(), PJM(), Ercot(), SPP(), NYISO(), ISONE()]
 
 
-def check_lmp_columns(df):
-    assert set(df.columns) == set(
+def check_lmp_columns(df, market):
+    assert set(
         [
             "Time",
             "Market",
@@ -21,9 +21,9 @@ def check_lmp_columns(df):
             "Congestion",
             "Loss",
         ],
-    )
+    ).issubset(df.columns)
 
-    # todo check if market is valid enum
+    assert df["Market"].unique()[0] == market.value
 
 
 def check_forecast(df):
@@ -210,6 +210,15 @@ def test_get_historical_demand(iso):
                 "markets": [Markets.DAY_AHEAD_5_MIN, Markets.REAL_TIME_5_MIN],
             },
         },
+        {
+            PJM(): {
+                "markets": [
+                    Markets.REAL_TIME_5_MIN,
+                    Markets.REAL_TIME_HOURLY,
+                    Markets.DAY_AHEAD_HOURLY,
+                ],
+            },
+        },
     ],
 )
 def test_get_historical_lmp(test):
@@ -221,7 +230,7 @@ def test_get_historical_lmp(test):
         print(iso.iso_id, m)
         hist = iso.get_historical_lmp(date_str, m)
         assert isinstance(hist, pd.DataFrame)
-        check_lmp_columns(hist)
+        check_lmp_columns(hist, m)
 
 
 @pytest.mark.parametrize(
@@ -251,6 +260,13 @@ def test_get_historical_lmp(test):
                 "markets": [Markets.DAY_AHEAD_5_MIN, Markets.REAL_TIME_5_MIN],
             },
         },
+        {
+            PJM(): {
+                "markets": [
+                    Markets.DAY_AHEAD_HOURLY,
+                ],
+            },
+        },
     ],
 )
 def test_get_latest_lmp(test):
@@ -263,7 +279,7 @@ def test_get_latest_lmp(test):
         print(iso.iso_id, m)
         latest = iso.get_latest_lmp(m)
         assert isinstance(latest, pd.DataFrame)
-        check_lmp_columns(latest)
+        check_lmp_columns(latest, m)
 
 
 @pytest.mark.parametrize(
@@ -288,6 +304,13 @@ def test_get_latest_lmp(test):
                 "markets": [Markets.DAY_AHEAD_5_MIN, Markets.REAL_TIME_5_MIN],
             },
         },
+        {
+            PJM(): {
+                "markets": [
+                    Markets.DAY_AHEAD_HOURLY,
+                ],
+            },
+        },
     ],
 )
 def test_get_lmp_today(test):
@@ -297,7 +320,7 @@ def test_get_lmp_today(test):
     for m in markets:
         today = iso.get_lmp_today(m)
         assert isinstance(today, pd.DataFrame)
-        check_lmp_columns(today)
+        check_lmp_columns(today, m)
 
 
 @pytest.mark.parametrize("iso", [ISONE(), CAISO(), NYISO()])

--- a/release.md
+++ b/release.md
@@ -1,7 +1,7 @@
 # How to release
 
 1. Bump version in `isodata/version.py` and `isodata/tests/test_version.py`
-2. run `update_readme.py` to update the method availability table
+2. run `update_readme.py` to update the method availability tables
 3. Update `CHANGELOG.md`
 4. Make release on GitHub and tag it with a matching version number
 5. Confirm package was uploaded to [PyPi](https://pypi.org/project/isodata/)


### PR DESCRIPTION
Adding LMPs for PJM. 

Notes:
* Supports the following markets for historical data: `REAL_TIME_5_MIN`, `REAL_TIME_HOURLY`, `DAY_AHEAD_HOURLY`
* Only supports current day data for `DAY_AHEAD_HOURLY`  (limitation of PJM's api)
* If no location is provided, by default, will return the LMPs for each of the Hubs
* if you want to get a specific location you must provide a list of p node ids. You can look those up [here](https://dataminer2.pjm.com/feed/pnode) or using `PJM().get_pnode_ids()`.


## Usage

### Get Hub LMP for DAY_AHEAD_HOURLY
```
>>> import isodata
>>> iso = isodata.PJM()
>>> iso.get_historical_lmp("Oct 1, 2022", market="DAY_AHEAD_HOURLY")
```
```
                         Time            Market   Location    Location Name Location Type        LMP  Energy  Congestion      Loss
0   2022-10-01 00:00:00-04:00  DAY_AHEAD_HOURLY      51217      EASTERN HUB           HUB  43.702288   42.70    0.204816  0.797472
1   2022-10-01 00:00:00-04:00  DAY_AHEAD_HOURLY      51287     WEST INT HUB           HUB  42.353333   42.70    0.065000 -0.411667
2   2022-10-01 00:00:00-04:00  DAY_AHEAD_HOURLY      51288      WESTERN HUB           HUB  43.505102   42.70    0.058438  0.746664
3   2022-10-01 00:00:00-04:00  DAY_AHEAD_HOURLY    4669664   NEW JERSEY HUB           HUB  43.379946   42.70    0.211035  0.468911
4   2022-10-01 00:00:00-04:00  DAY_AHEAD_HOURLY   33092311  CHICAGO GEN HUB           HUB  40.052000   42.70   -0.676308 -1.971692
..                        ...               ...        ...              ...           ...        ...     ...         ...       ...
295 2022-10-02 00:00:00-04:00  DAY_AHEAD_HOURLY   34497125      AEP GEN HUB           HUB  35.431842   35.66    0.335000 -0.563158
296 2022-10-02 00:00:00-04:00  DAY_AHEAD_HOURLY   34497127   AEP-DAYTON HUB           HUB  35.443102   35.66   -0.245069  0.028171
297 2022-10-02 00:00:00-04:00  DAY_AHEAD_HOURLY   34497151         OHIO HUB           HUB  35.067340   35.66   -0.618274  0.025614
298 2022-10-02 00:00:00-04:00  DAY_AHEAD_HOURLY   35010337     DOMINION HUB           HUB  37.788569   35.66    1.519467  0.609102
299 2022-10-02 00:00:00-04:00  DAY_AHEAD_HOURLY  116013751     ATSI GEN HUB           HUB  35.171818   35.66    0.227273 -0.715455

[300 rows x 9 columns]
```

### Get REAL_TIME_HOURLY for Zones

For example, to get all of the zonal LMPs

```
>>> import isodata
>>> iso = isodata.PJM()
>>> nodes = iso.get_pnode_ids()
>>> zones = nodes[nodes["pnode_subtype"] == "ZONE"]
>>> zone_ids = zones["pnode_id"].tolist()
>>> iso.get_historical_lmp("Oct 1, 2022", market="REAL_TIME_HOURLY", locations=zone_ids)
```
```
                         Time            Market    Location Location Name Location Type        LMP  Energy  Congestion      Loss
0   2022-10-01 00:00:00-04:00  REAL_TIME_HOURLY           1       PJM-RTO          ZONE  39.206879   39.16    0.021483  0.027896
1   2022-10-01 00:00:00-04:00  REAL_TIME_HOURLY           3   MID-ATL/APS          ZONE  39.612191   39.16    0.584017 -0.129326
2   2022-10-01 00:00:00-04:00  REAL_TIME_HOURLY       51291          AECO          ZONE  39.466311   39.16    0.584651 -0.275839
3   2022-10-01 00:00:00-04:00  REAL_TIME_HOURLY       51292           BGE          ZONE  40.855482   39.16    0.788565  0.909417
4   2022-10-01 00:00:00-04:00  REAL_TIME_HOURLY       51293           DPL          ZONE  39.812640   39.16    0.617380  0.037760
..                        ...               ...         ...           ...           ...        ...     ...         ...       ...
570 2022-10-02 00:00:00-04:00  REAL_TIME_HOURLY    37737283           DUQ          ZONE  30.327211   30.51    0.340839 -0.524461
571 2022-10-02 00:00:00-04:00  REAL_TIME_HOURLY   116013753          ATSI          ZONE  29.951154   30.51   -0.116830 -0.442849
572 2022-10-02 00:00:00-04:00  REAL_TIME_HOURLY   124076095          DEOK          ZONE  30.677389   30.51   -0.108612  0.275168
573 2022-10-02 00:00:00-04:00  REAL_TIME_HOURLY   970242670          EKPC          ZONE  33.513077   30.51    2.765612  0.236632
574 2022-10-02 00:00:00-04:00  REAL_TIME_HOURLY  1709725933          OVEC          ZONE  30.848333   30.51    0.380000 -0.042500

[575 rows x 9 columns]
```

### Get P Node Ids
If you want to get data for a specific p node, you must use the p node id, not the name
```
>>> import isodata
>>> iso = isodata.PJM()
>>> nodes = iso.get_pnode_ids()
>>> nodes
```
```
         pnode_id                pnode_name pnode_type pnode_subtype  zone voltage_level       effective_date     termination_date
0               0                       PJM  AGGREGATE          ZONE  None          None  1998-04-01T00:00:00  2005-01-01T00:00:00
1               1                   PJM-RTO  AGGREGATE          ZONE  None          None  2017-09-08T00:00:00  9999-12-31T00:00:00
2               2                        NI  AGGREGATE          ZONE  None          None  2004-05-01T00:00:00  2004-10-01T00:00:00
3               3               MID-ATL/APS  AGGREGATE          ZONE  None          None  2017-09-08T00:00:00  9999-12-31T00:00:00
4               4                       MAD     LOCALE          None  None          None  2012-10-01T00:00:00  2017-06-02T00:00:00
...           ...                       ...        ...           ...   ...           ...                  ...                  ...
18798  2156113476  FINLEY  34.5 KV MADSNFSP        BUS           GEN  ATSI       34.5 KV  2022-09-14T00:00:00  9999-12-31T00:00:00
18799  2156113479        MIDWAYAP69 KV   T2        BUS          LOAD   AEP         69 KV  2022-09-14T00:00:00  9999-12-31T00:00:00
18800  2156113482     ZOAR    69 KV   LOAD2        BUS          LOAD   DPL         69 KV  2022-09-14T00:00:00  9999-12-31T00:00:00
18801  2156113488      BERGEN  13 KV   CC12        BUS           GEN  PSEG         13 KV  2022-09-14T00:00:00  9999-12-31T00:00:00
18802  2156113489       PLAUDERV69 KV   T-1        BUS          LOAD  PSEG         69 KV  2022-09-14T00:00:00  9999-12-31T00:00:00

[18803 rows x 8 columns]
```