### PR TITLE
Adding "infer" param to tz conversion

### DIFF
--- a/isodata/pjm.py
+++ b/isodata/pjm.py
@@ -270,7 +270,7 @@ class PJM(ISOBase):
 
         data["Time"] = pd.to_datetime(data["Time"]).dt.tz_localize(
             self.default_timezone,
-            ambiguous='infer',
+            ambiguous="infer",
         )
 
         data = data[

--- a/isodata/pjm.py
+++ b/isodata/pjm.py
@@ -270,6 +270,7 @@ class PJM(ISOBase):
 
         data["Time"] = pd.to_datetime(data["Time"]).dt.tz_localize(
             self.default_timezone,
+            ambiguous='infer',
         )
 
         data = data[


### PR DESCRIPTION
Calling the historical prices method for PJM throws a `AmbiguousTimeError` on days when we "fall" back. Caught this while scraping price data for 2021 and assuming it will happen on daylight savings this year as well. 

To reproduce: 
`iso.get_historical_lmp(
    date="Nov 7, 2021",
    market='REAL_TIME_HOURLY', 
    locations=['50655'],
)`