### PR TITLE
Add date range querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 
 - Add gas prices to CAISO
+- Add GHG allowance price to CAISO
 
 ## v0.8.0 - Oct 13, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vNext
 
+- Support querying by date range for CAISO, PJM, NYISO, and ISONE Hisotrical Methods
 - Add gas prices to CAISO
 - Add GHG allowance price to CAISO
 

--- a/isodata/__init__.py
+++ b/isodata/__init__.py
@@ -3,6 +3,7 @@ from isodata.version import __version__
 from isodata.utils import list_isos, get_iso, make_availability_table
 from isodata import tests
 import isodata.base
+import isodata.decorators
 
 from isodata.base import Markets
 

--- a/isodata/caiso.py
+++ b/isodata/caiso.py
@@ -382,7 +382,13 @@ class CAISO(ISOBase):
         df["Time"] = pd.to_datetime(
             df["Time"],
         ).dt.tz_convert(self.default_timezone)
-        df = df.sort_values("Time").sort_values(["Fuel Region Id", "Time"])
+        df = (
+            df.sort_values("Time")
+            .sort_values(
+                ["Fuel Region Id", "Time"],
+            )
+            .reset_index(drop=True)
+        )
 
         return df
 

--- a/isodata/caiso.py
+++ b/isodata/caiso.py
@@ -1,98 +1,15 @@
-import functools
 import io
 import time
 from sre_parse import Verbose
-from typing import Any
-from unicodedata import name
 from zipfile import ZipFile
 
 import pandas as pd
 import requests
-import tqdm
-from numpy import isin
 
 import isodata
 from isodata import utils
 from isodata.base import FuelMix, GridStatus, ISOBase, Markets
-
-
-def do_twice(func):
-    def wrapper_do_twice(*args, **kwargs):
-        func(*args, **kwargs)
-        return func(*args, **kwargs)
-
-    return wrapper_do_twice
-
-
-def _get_args_dict(fn, args, kwargs):
-    args_names = fn.__code__.co_varnames[: fn.__code__.co_argcount]
-    return {**dict(zip(args_names, args)), **kwargs}
-
-
-class support_date_range:
-    def __init__(self, max_days_per_request):
-        """Maximum number of days that can be queried at once"""
-        assert max_days_per_request > 0, "max_days_per_request must be greater than 0"
-        self.max_days_per_request = max_days_per_request
-
-    def __call__(self, f):
-        @functools.wraps(f)
-        def wrapped_f(*args, **kwargs):
-            args_dict = _get_args_dict(f, args, kwargs)
-
-            args_dict["date"] = isodata.utils._handle_date(
-                args_dict["date"],
-                args_dict["self"].default_timezone,
-            )
-
-            # no date range handling required
-            if "end" not in args_dict:
-                return f(**args_dict)
-            else:
-                args_dict["end"] = isodata.utils._handle_date(
-                    args_dict["end"],
-                    args_dict["self"].default_timezone,
-                )
-
-            # use .date() to remove timezone info, which doesnt matter if just a date
-            dates = pd.date_range(
-                args_dict["date"].date(),
-                args_dict["end"].date(),
-                freq=f"{self.max_days_per_request}D",
-                inclusive="left",
-            )
-
-            # add end date since it's not included
-            dates = dates.tolist() + [args_dict["end"]]
-            dates = [
-                isodata.utils._handle_date(
-                    d,
-                    args_dict["self"].default_timezone,
-                )
-                for d in dates
-            ]
-            start_date = dates[0]
-
-            if self.max_days_per_request == 1:
-                del args_dict["end"]
-
-            all_df = []
-            for end_date in tqdm.tqdm(
-                dates[1:],
-                disable=not args_dict.get("verbose", False),
-            ):
-                args_dict["date"] = start_date
-                if self.max_days_per_request > 1:
-                    args_dict["end"] = end_date
-
-                df = f(**args_dict)
-
-                all_df.append(df)
-                start_date = end_date
-            df = pd.concat(all_df)
-            return df
-
-        return wrapped_f
+from isodata.decorators import support_date_range
 
 
 class CAISO(ISOBase):

--- a/isodata/decorators.py
+++ b/isodata/decorators.py
@@ -1,5 +1,6 @@
 import functools
 
+import pandas as pd
 import tqdm
 
 import isodata

--- a/isodata/decorators.py
+++ b/isodata/decorators.py
@@ -39,19 +39,19 @@ class support_date_range:
 
             # use .date() to remove timezone info, which doesnt matter if just a date
 
-            if sys.version_info <= (3, 7):
-                dates = pd.date_range(
-                    args_dict["date"].date(),
-                    args_dict["end"].date(),
-                    freq=f"{self.max_days_per_request}D",
-                    closed="left",
-                )
-            else:
+            try:
                 dates = pd.date_range(
                     args_dict["date"].date(),
                     args_dict["end"].date(),
                     freq=f"{self.max_days_per_request}D",
                     inclusive="left",
+                )
+            except TypeError:
+                dates = pd.date_range(
+                    args_dict["date"].date(),
+                    args_dict["end"].date(),
+                    freq=f"{self.max_days_per_request}D",
+                    closed="left",
                 )
 
             # add end date since it's not included

--- a/isodata/decorators.py
+++ b/isodata/decorators.py
@@ -23,6 +23,24 @@ class support_date_range:
         def wrapped_f(*args, **kwargs):
             args_dict = _get_args_dict(f, args, kwargs)
 
+            if "date" in args_dict and "start" in args_dict:
+                raise ValueError(
+                    "Cannot supply both 'date' and 'start' to function {}".format(
+                        f,
+                    ),
+                )
+
+            if "date" not in args_dict and "start" not in args_dict:
+                raise ValueError(
+                    "Must supply either 'date' or 'start' to function {}".format(
+                        f,
+                    ),
+                )
+
+            if "start" in args_dict:
+                args_dict["date"] = args_dict["start"]
+                del args_dict["start"]
+
             args_dict["date"] = isodata.utils._handle_date(
                 args_dict["date"],
                 args_dict["self"].default_timezone,

--- a/isodata/decorators.py
+++ b/isodata/decorators.py
@@ -1,4 +1,5 @@
 import functools
+import sys
 
 import pandas as pd
 import tqdm
@@ -37,12 +38,21 @@ class support_date_range:
                 )
 
             # use .date() to remove timezone info, which doesnt matter if just a date
-            dates = pd.date_range(
-                args_dict["date"].date(),
-                args_dict["end"].date(),
-                freq=f"{self.max_days_per_request}D",
-                inclusive="left",
-            )
+
+            if sys.version_info <= (3, 7):
+                dates = pd.date_range(
+                    args_dict["date"].date(),
+                    args_dict["end"].date(),
+                    freq=f"{self.max_days_per_request}D",
+                    closed="left",
+                )
+            else:
+                dates = pd.date_range(
+                    args_dict["date"].date(),
+                    args_dict["end"].date(),
+                    freq=f"{self.max_days_per_request}D",
+                    inclusive="left",
+                )
 
             # add end date since it's not included
             dates = dates.tolist() + [args_dict["end"]]

--- a/isodata/decorators.py
+++ b/isodata/decorators.py
@@ -39,6 +39,7 @@ class support_date_range:
 
             # use .date() to remove timezone info, which doesnt matter if just a date
 
+            # if using python 3.7, there will be an older version of pandas installed that must used closed
             try:
                 dates = pd.date_range(
                     args_dict["date"].date(),

--- a/isodata/decorators.py
+++ b/isodata/decorators.py
@@ -1,0 +1,76 @@
+import functools
+
+import tqdm
+
+import isodata
+
+
+def _get_args_dict(fn, args, kwargs):
+    args_names = fn.__code__.co_varnames[: fn.__code__.co_argcount]
+    return {**dict(zip(args_names, args)), **kwargs}
+
+
+class support_date_range:
+    def __init__(self, max_days_per_request):
+        """Maximum number of days that can be queried at once"""
+        assert max_days_per_request > 0, "max_days_per_request must be greater than 0"
+        self.max_days_per_request = max_days_per_request
+
+    def __call__(self, f):
+        @functools.wraps(f)
+        def wrapped_f(*args, **kwargs):
+            args_dict = _get_args_dict(f, args, kwargs)
+
+            args_dict["date"] = isodata.utils._handle_date(
+                args_dict["date"],
+                args_dict["self"].default_timezone,
+            )
+
+            # no date range handling required
+            if "end" not in args_dict:
+                return f(**args_dict)
+            else:
+                args_dict["end"] = isodata.utils._handle_date(
+                    args_dict["end"],
+                    args_dict["self"].default_timezone,
+                )
+
+            # use .date() to remove timezone info, which doesnt matter if just a date
+            dates = pd.date_range(
+                args_dict["date"].date(),
+                args_dict["end"].date(),
+                freq=f"{self.max_days_per_request}D",
+                inclusive="left",
+            )
+
+            # add end date since it's not included
+            dates = dates.tolist() + [args_dict["end"]]
+            dates = [
+                isodata.utils._handle_date(
+                    d,
+                    args_dict["self"].default_timezone,
+                )
+                for d in dates
+            ]
+            start_date = dates[0]
+
+            if self.max_days_per_request == 1:
+                del args_dict["end"]
+
+            all_df = []
+            for end_date in tqdm.tqdm(
+                dates[1:],
+                disable=False,
+            ):
+                args_dict["date"] = start_date
+                if self.max_days_per_request > 1:
+                    args_dict["end"] = end_date
+
+                df = f(**args_dict)
+
+                all_df.append(df)
+                start_date = end_date
+            df = pd.concat(all_df)
+            return df
+
+        return wrapped_f

--- a/isodata/isone.py
+++ b/isodata/isone.py
@@ -50,16 +50,16 @@ class ISONE(ISOBase):
 
         # historical data available
         # https://www.iso-ne.com/markets-operations/system-forecast-status/current-system-status/power-system-status-list
-        r = requests.post(
-            "https://www.iso-ne.com/ws/wsclient",
+        data = _make_wsclient_request(
+            url="https://www.iso-ne.com/ws/wsclient",
             data={
                 "_nstmp_requestType": "systemconditions",
                 "_nstmp_requestUrl": "/powersystemconditions/current",
             },
-        ).json()
+        )
 
         # looks like it could return multiple entries
-        condition = r[0]["data"]["PowerSystemConditions"]["PowerSystemCondition"][0]
+        condition = data[0]["data"]["PowerSystemConditions"]["PowerSystemCondition"][0]
         status = condition["SystemCondition"]
         note = condition["ActionDescription"]
         time = pd.Timestamp.now(tz=self.default_timezone).floor(freq="s")
@@ -73,11 +73,11 @@ class ISONE(ISOBase):
         )
 
     def get_latest_fuel_mix(self):
-        r = requests.post(
-            "https://www.iso-ne.com/ws/wsclient",
+        data = _make_wsclient_request(
+            url="https://www.iso-ne.com/ws/wsclient",
             data={"_nstmp_requestType": "fuelmix"},
-        ).json()
-        mix_df = pd.DataFrame(r[0]["data"]["GenFuelMixes"]["GenFuelMix"])
+        )
+        mix_df = pd.DataFrame(data[0]["data"]["GenFuelMixes"]["GenFuelMix"])
         time = pd.Timestamp(
             mix_df["BeginDate"].max(),
             tz=self.default_timezone,
@@ -184,12 +184,12 @@ class ISONE(ISOBase):
             "_nstmp_inclBtmPv": True,
         }
 
-        r = requests.post(
-            "https://www.iso-ne.com/ws/wsclient",
+        data = _make_wsclient_request(
+            url="https://www.iso-ne.com/ws/wsclient",
             data=data,
-        ).json()
+        )
 
-        data = pd.DataFrame(r[0]["data"]["forecast"])
+        data = pd.DataFrame(data[0]["data"]["forecast"])
 
         data["BeginDate"] = pd.to_datetime(data["BeginDate"]).dt.tz_convert(
             self.default_timezone,
@@ -438,6 +438,13 @@ def _make_request(url, skiprows):
             print("Attempt {} failed. Retrying...".format(attempt + 1))
             attempt += 1
 
+        if r2.status_code != 200:
+            raise RuntimeError(
+                "Failed to get data from {}. Check if ISONE is down and try again later".format(
+                    url,
+                ),
+            )
+
         df = pd.read_csv(
             io.StringIO(r2.content.decode("utf8")),
             skiprows=skiprows,
@@ -445,3 +452,23 @@ def _make_request(url, skiprows):
             engine="python",
         )
         return df
+
+
+def _make_wsclient_request(url, data, verbose=False):
+    """Make request to ISO NE wsclient"""
+    if verbose:
+        print("Requesting data from {}".format(url))
+
+    r = requests.post(
+        "https://www.iso-ne.com/ws/wsclient",
+        data=data,
+    )
+
+    if r.status_code != 200:
+        raise RuntimeError(
+            "Failed to get data from {}. Check if ISONE is down and try again later".format(
+                url,
+            ),
+        )
+
+    return r.json()

--- a/isodata/isone.py
+++ b/isodata/isone.py
@@ -9,6 +9,7 @@ import requests
 import isodata
 from isodata import utils
 from isodata.base import FuelMix, GridStatus, ISOBase, Markets
+from isodata.decorators import support_date_range
 
 
 class ISONE(ISOBase):
@@ -92,6 +93,7 @@ class ISONE(ISOBase):
         # todo should this use the latest endpoint?
         return self._today_from_historical(self.get_historical_fuel_mix)
 
+    @support_date_range(max_days_per_request=1)
     def get_historical_fuel_mix(self, date):
         """Return fuel mix at a previous date
 
@@ -125,6 +127,7 @@ class ISONE(ISOBase):
     def get_demand_today(self):
         return self._today_from_historical(self.get_historical_demand)
 
+    @support_date_range(max_days_per_request=1)
     def get_historical_demand(self, date):
         """Return demand at a previous date in 5 minute intervals"""
         # todo document the earliest supported date
@@ -161,6 +164,7 @@ class ISONE(ISOBase):
         d = self._today_from_historical(self.get_historical_forecast)
         return d
 
+    @support_date_range(max_days_per_request=1)
     def get_historical_forecast(self, date):
         date = isodata.utils._handle_date(date)
 
@@ -246,6 +250,7 @@ class ISONE(ISOBase):
             include_id=include_id,
         )
 
+    @support_date_range(max_days_per_request=1)
     def get_historical_lmp(
         self,
         date,

--- a/isodata/nyiso.py
+++ b/isodata/nyiso.py
@@ -7,6 +7,7 @@ import requests
 import isodata
 from isodata import utils
 from isodata.base import FuelMix, GridStatus, ISOBase, Markets
+from isodata.decorators import support_date_range
 
 
 class NYISO(ISOBase):
@@ -33,6 +34,7 @@ class NYISO(ISOBase):
         d = self._today_from_historical(self.get_historical_status)
         return d
 
+    @support_date_range(max_days_per_request=1)
     def get_historical_status(self, date):
         """Get status event for a date"""
         status_df = self._download_nyiso_archive(date, "RealTimeEvents")
@@ -78,6 +80,7 @@ class NYISO(ISOBase):
         "Get fuel mix for today in 5 minute intervals"
         return self._today_from_historical(self.get_historical_fuel_mix)
 
+    @support_date_range(max_days_per_request=1)
     def get_historical_fuel_mix(self, date):
         mix_df = self._download_nyiso_archive(date, "rtfuelmix")
         mix_df = mix_df.pivot_table(
@@ -97,6 +100,7 @@ class NYISO(ISOBase):
         d = self._today_from_historical(self.get_historical_demand)
         return d
 
+    @support_date_range(max_days_per_request=1)
     def get_historical_demand(self, date):
         """Returns demand at a previous date in 5 minute intervals"""
         data = self._download_nyiso_archive(date, "pal")
@@ -133,6 +137,7 @@ class NYISO(ISOBase):
         d = self._today_from_historical(self.get_historical_forecast)
         return d
 
+    @support_date_range(max_days_per_request=1)
     def get_historical_forecast(self, date):
         """Get load forecast for a previous date in 1 hour intervals"""
         date = utils._handle_date(date, self.default_timezone)
@@ -154,6 +159,7 @@ class NYISO(ISOBase):
         "Get lmp for today"
         return self._today_from_historical(self.get_historical_lmp, market, locations)
 
+    @support_date_range(max_days_per_request=1)
     def get_historical_lmp(self, date, market: str, locations: list = None):
         """
         Supported Markets: REAL_TIME_5_MIN, DAY_AHEAD_5_MIN

--- a/isodata/pjm.py
+++ b/isodata/pjm.py
@@ -5,6 +5,7 @@ import requests
 
 import isodata
 from isodata.base import FuelMix, ISOBase, Markets
+from isodata.decorators import support_date_range
 
 
 class PJM(ISOBase):
@@ -29,6 +30,7 @@ class PJM(ISOBase):
         "Get fuel mix for today in hourly intervals"
         return self._today_from_historical(self.get_historical_fuel_mix)
 
+    @support_date_range(max_days_per_request=1)
     def get_historical_fuel_mix(self, date):
         date = date = isodata.utils._handle_date(date)
         tomorrow = date + pd.DateOffset(1)
@@ -79,6 +81,7 @@ class PJM(ISOBase):
         "Get demand for today in 5 minute intervals"
         return self._today_from_historical(self.get_historical_demand)
 
+    @support_date_range(max_days_per_request=1)
     def get_historical_demand(self, date):
         """Returns demand at a previous date at 5 minute intervals
 
@@ -198,6 +201,7 @@ class PJM(ISOBase):
             raise NotImplementedError("Only supports DAY_AHEAD_HOURLY")
         return self._today_from_historical(self.get_historical_lmp, market, locations)
 
+    @support_date_range(max_days_per_request=1)
     def get_historical_lmp(
         self,
         date,

--- a/isodata/tests/test_caiso.py
+++ b/isodata/tests/test_caiso.py
@@ -32,3 +32,12 @@ def test_get_historical_gas_prices():
         [test_region_1, test_region_2],
     )
     assert len(df) == 24 * 2
+
+
+def test_get_historical_ghg_allowance():
+    iso = isodata.CAISO()
+    date = "Oct 15, 2022"
+    df = iso.get_historical_ghg_allowance(date)
+
+    assert len(df) == 1
+    assert set(df.columns) == {"Time", "GHG Allowance Price"}

--- a/isodata/tests/test_ercot.py
+++ b/isodata/tests/test_ercot.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 
 import isodata

--- a/isodata/tests/test_ercot.py
+++ b/isodata/tests/test_ercot.py
@@ -1,0 +1,10 @@
+import pytest
+
+import isodata
+
+
+@pytest.mark.skip(reason="takes too long to run")
+def test_ercot_get_historical_rtm_spp():
+    rtm = isodata.Ercot().get_historical_rtm_spp(2020)
+    assert isinstance(rtm, pd.DataFrame)
+    assert len(rtm) > 0

--- a/isodata/tests/test_isos.py
+++ b/isodata/tests/test_isos.py
@@ -356,3 +356,15 @@ def test_get_historical_storage(iso):
     test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
     storage = iso.get_historical_storage(test_date)
     check_storage(storage)
+
+
+@pytest.mark.parametrize("iso", [ISONE(), NYISO(), PJM(), CAISO()])
+def test_get_historical_with_date_range(iso):
+    # range not inclusive, add one to include today
+    end = pd.Timestamp.now() + pd.Timedelta(days=1)
+    num_days = 7
+    start = end - pd.Timedelta(days=num_days)
+
+    data = iso.get_historical_fuel_mix(date=start.date(), end=end.date())
+    # make sure right number of days are returned
+    assert data["Time"].dt.day.nunique() == num_days

--- a/isodata/tests/test_isos.py
+++ b/isodata/tests/test_isos.py
@@ -368,3 +368,21 @@ def test_get_historical_with_date_range(iso):
     data = iso.get_historical_fuel_mix(date=start.date(), end=end.date())
     # make sure right number of days are returned
     assert data["Time"].dt.day.nunique() == num_days
+
+
+@pytest.mark.parametrize("iso", [ISONE(), NYISO(), PJM(), CAISO()])
+def test_date_or_start(iso):
+    end = pd.Timestamp.now() + pd.Timedelta(days=1)
+    num_days = 2
+    start = end - pd.Timedelta(days=num_days)
+
+    data_date = iso.get_historical_fuel_mix(date=start.date(), end=end.date())
+    data_start = iso.get_historical_fuel_mix(
+        start=start.date(),
+        end=end.date(),
+    )
+    data_date = iso.get_historical_fuel_mix(date=start.date())
+    data_start = iso.get_historical_fuel_mix(start=start.date())
+
+    with pytest.raises(ValueError):
+        iso.get_historical_fuel_mix(start=start.date(), date=start.date())

--- a/isodata/tests/test_isos.py
+++ b/isodata/tests/test_isos.py
@@ -356,16 +356,3 @@ def test_get_historical_storage(iso):
     test_date = (pd.Timestamp.now() - pd.Timedelta(days=14)).date()
     storage = iso.get_historical_storage(test_date)
     check_storage(storage)
-
-
-@pytest.mark.skip(reason="takes too long to run")
-def test_ercot_get_historical_rtm_spp():
-    rtm = Ercot().get_historical_rtm_spp(2020)
-    assert isinstance(rtm, pd.DataFrame)
-    assert len(rtm) > 0
-
-
-def test_miso_locations():
-    iso = MISO()
-    data = iso.get_latest_lmp(Markets.REAL_TIME_5_MIN, locations=iso.hubs)
-    assert set(data["Location"].unique()) == set(iso.hubs)

--- a/isodata/tests/test_miso.py
+++ b/isodata/tests/test_miso.py
@@ -1,0 +1,7 @@
+import isodata
+
+
+def test_miso_locations():
+    iso = isodata.MISO()
+    data = iso.get_latest_lmp(Markets.REAL_TIME_5_MIN, locations=iso.hubs)
+    assert set(data["Location"].unique()) == set(iso.hubs)

--- a/isodata/tests/test_miso.py
+++ b/isodata/tests/test_miso.py
@@ -1,4 +1,5 @@
 import isodata
+from isodata.base import Markets
 
 
 def test_miso_locations():

--- a/isodata/tests/test_pjm.py
+++ b/isodata/tests/test_pjm.py
@@ -1,0 +1,15 @@
+import pytest
+
+import isodata
+
+
+def test_pjm_handle_error():
+    o = isodata.PJM()
+
+    # TODO this should stop raising erros in the future when archived data is supported
+    with pytest.raises(RuntimeError):
+        o.get_historical_lmp(
+            date="4/15/2022",
+            market="REAL_TIME_5_MIN",
+            locations=None,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pandas >= 1.3.0",
     "beautifulsoup4 >= 4.8.13",
     "tabulate >= 0.8.10",
+    "tqdm >= 4.64.1"
 ]
 
 [project.urls]


### PR DESCRIPTION
Query for range of dates by supplying `start` and `end` parameters. Work for all `.get_historical_*` methods

Resolves #37 and #52

Supports: CAISO, PJM, ISONE, and NYISO

# Usage Examples

## NYISO Fuel Mix

```python
>>> import isodata
>>> import pandas as pd
>>> iso = isodata.NYISO()
>>> iso.get_historical_fuel_mix(start="April 1, 2022", end="June 14, 2022")
```
```
Fuel Category                      Time  Dual Fuel   Hydro  Natural Gas  Nuclear  Other Fossil Fuels  Other Renewables    Wind
0             2022-04-01 00:05:00-04:00     3217.0  2933.0       2022.0   3340.0                 3.0             268.0  1175.0
1             2022-04-01 00:10:00-04:00     3271.0  2981.0       2077.0   3336.0                 3.0             268.0  1243.0
2             2022-04-01 00:15:00-04:00     3189.0  3075.0       2043.0   3337.0                 3.0             268.0  1267.0
3             2022-04-01 00:20:00-04:00     3118.0  3181.0       1975.0   3338.0                 3.0             269.0  1286.0
4             2022-04-01 00:25:00-04:00     3089.0  3198.0       1903.0   3333.0                 3.0             269.0  1306.0
..                                  ...        ...     ...          ...      ...                 ...               ...     ...
311           2022-06-13 23:50:00-04:00     3877.0  2753.0       4034.0   3287.0                 0.0             277.0   201.0
312           2022-06-13 23:53:54-04:00     3759.0  2823.0       4071.0   3278.0                 0.0             277.0   195.0
313           2022-06-13 23:55:00-04:00     3684.0  2892.0       4099.0   3281.0                 0.0             278.0   191.0
314           2022-06-13 23:55:12-04:00     3685.0  2913.0       4104.0   3278.0                 0.0             278.0   191.0
315           2022-06-14 00:00:00-04:00     3660.0  2809.0       4041.0   3277.0                 0.0             278.0   176.0

[21971 rows x 8 columns]
```

## CAISO LMPs
```python
import isodata
caiso = isodata.CAISO()
locations = ['TH_NP15_GEN-APND', 'TH_SP15_GEN-APND', 'TH_ZP26_GEN-APND']
lmp_df = caiso.get_historical_lmp(start="Jan 1, 2022", end="Oct 20, 2022", market='DAY_AHEAD_HOURLY', locations=locations, verbose=True)
lmp_df
```
```
LMP_TYPE	Time	Market	Location	Location Type	LMP	Energy	Congestion	Loss
0	2022-01-01 00:00:00-08:00	DAY_AHEAD_HOURLY	TH_NP15_GEN-APND	Trading Hub	59.57375	59.97558	0.00000	-0.40184
1	2022-01-01 00:00:00-08:00	DAY_AHEAD_HOURLY	TH_SP15_GEN-APND	Trading Hub	57.67852	59.97558	0.00000	-2.29706
2	2022-01-01 00:00:00-08:00	DAY_AHEAD_HOURLY	TH_ZP26_GEN-APND	Trading Hub	57.58855	59.97558	0.00000	-2.38703
3	2022-01-01 01:00:00-08:00	DAY_AHEAD_HOURLY	TH_NP15_GEN-APND	Trading Hub	61.73845	62.34318	0.00000	-0.60473
4	2022-01-01 01:00:00-08:00	DAY_AHEAD_HOURLY	TH_SP15_GEN-APND	Trading Hub	60.24222	62.34318	0.00000	-2.10097
...	...	...	...	...	...	...	...	...
931	2022-10-19 22:00:00-07:00	DAY_AHEAD_HOURLY	TH_SP15_GEN-APND	Trading Hub	91.19447	93.26537	-0.00974	-2.06116
932	2022-10-19 22:00:00-07:00	DAY_AHEAD_HOURLY	TH_ZP26_GEN-APND	Trading Hub	89.41351	93.26537	0.00000	-3.85186
933	2022-10-19 23:00:00-07:00	DAY_AHEAD_HOURLY	TH_NP15_GEN-APND	Trading Hub	84.40075	89.43164	-1.33737	-3.69353
934	2022-10-19 23:00:00-07:00	DAY_AHEAD_HOURLY	TH_SP15_GEN-APND	Trading Hub	86.55195	89.43164	0.00000	-2.87970
935	2022-10-19 23:00:00-07:00	DAY_AHEAD_HOURLY	TH_ZP26_GEN-APND	Trading Hub	86.13162	89.43164	0.00000	-3.30003
```